### PR TITLE
Code and documentation for cstr/pfr reaction examples

### DIFF
--- a/examples/simple_reactors/cstr/irreversible/CONFIG
+++ b/examples/simple_reactors/cstr/irreversible/CONFIG
@@ -1,0 +1,37 @@
+[INPUT]
+opencmp_config_file_path    = ../../fake_sim_input/config_hydrodynamics
+opencmp_sol_file_path       = ../../fake_sim_input/output/ins_sol/ins_0.0.sol
+num_refinements             = 0
+min_magnitude_threshold     = 6e-5
+
+no_flux_names       = None
+ignored_names       = ("top", "bottom")
+domain_inlet_names  = ("left",)
+domain_outlet_names = ("right",)
+
+[COMPARTMENTALIZATION]
+min_compartment_size = 0.999
+bc_names_for_seeds  = ("left",)
+
+[COMPARTMENT MODELLING]
+model = CSTR
+
+[SIMULATION]
+run                 = True
+rtol                = 1e-13
+atol				= 1e-13
+t_span              = 0, 50
+specie_names        = a, b, c
+reactions_file_path = reactions
+initial_conditions  = a -> 2
+                      b -> 0
+                      c -> 0
+boundary_conditions = a: left -> 2
+                      b: left -> 0
+                      c: left -> 0
+
+[POST-PROCESSING]
+inlet_bc_name          = left
+outlet_bc_name         = right
+output_VTK             = True
+

--- a/examples/simple_reactors/cstr/irreversible/analysis.tex
+++ b/examples/simple_reactors/cstr/irreversible/analysis.tex
@@ -1,0 +1,150 @@
+\documentclass[a4paper,12pt]{article}
+\usepackage[margin=0.65in]{geometry}
+\usepackage{amsmath,amssymb,amstext}
+\usepackage[hidelinks]{hyperref}
+\usepackage{graphicx}
+\usepackage{float}
+
+\usepackage{setspace}
+\setlength{\parskip}{0.65cm}
+\singlespacing
+
+\setlength{\parindent}{0cm}
+
+\begin{document}
+
+\title{\texttt{OpenCCM} CSTR Validation: Irreversible Linear Reactions}
+\author{Matthew Peres Tino}
+\maketitle
+
+\section{Reaction System}
+
+This problem closely follows that of Example 8.3/8.4 from \emph{Elements of Chemical Reaction Engineering, 5th ed.} by H. Scott Fogler.
+Suppose we have the following irreversible coupled linear reaction system:
+\begin{center}
+	$A\xrightarrow[]{k_1} B$
+
+	$B\xrightarrow[]{k_2} C$
+\end{center}
+where $k_1 = 0.5$ $hr^{-1}$ and $k_2 = 0.2$ $hr^{-1}$. 
+The reaction rates are easily derived, and are as follows:
+\begin{align}
+    r_A &= -k_1 C_A \\
+    r_B &= k_1 C_A - k_2 C_B \\
+    r_C &= k_2 C_B
+\end{align}
+
+\section{CSTR Mass Balance}
+
+A transient mass balance for a species $P$ in a CSTR is as follows. 
+\begin{align}
+    \frac{dN_P}{dt} &= F_{in} - F_{out} + Vr_P\\
+    V\frac{dC_P}{dt} &= Q P_{IN} - QC_P + Vr_P \\
+    \frac{dC_P}{dt} &= \frac{P_{IN}}{\tau} - \frac{C_P}{\tau} + r_P
+\end{align}
+where $N_P$ is the number of moles, $F$ represents the molar flow rate in $mol/s$, $V$ is the volume of the CSTR, $r_P$ is the reaction rate, and $C_P$ and $P_{IN}$ represent the concentration of species $P$ and the inlet feed rate (which plays the role of a ``boundary condition''), respectively.
+Solving for constant volume $V$ and volumetric feed rate $Q$ allows for simplifications as shown above, where $\tau = \frac{V}{Q}$.
+
+\subsection{Mass Balance for $A$}
+Using the formula above, the mass balance for species $A$ is: $$ \frac{dC_A}{dt} = \frac{A_{IN}}{\tau} - \frac{C_A}{\tau} -k_1 C_A$$
+This is a first order ODE that is easily solved by the integrating factor method. 
+Let $\alpha_A = \frac{A_{IN}}{\tau}$ and $\beta_A = \frac{k_1\tau + 1}{\tau} $.
+\begin{align}
+    \frac{dC_A}{dt} + \beta_A C_A &= \alpha_A \\
+    \frac{d}{dt}(C_A e^{\beta_A t}) &= \alpha_A e^{\beta_A t} \\ 
+    C_A(t) &= \frac{\alpha_A}{\beta_A} + \gamma e^{-\beta_A t}
+\end{align}
+Note both the initial condition ($C_{A0}$) and inlet feed rate ($A_{IN}$) = 2M. 
+Applying the initial condition yields $\gamma = A_{IN} - \frac{\alpha_A}{\beta_A}$. 
+After some simplifications, we obtain the analytical transient mass balance expression for $A$: 
+\begin{equation}
+    C_A(t) = \frac{A_{IN}}{1+ k_1\tau} (1+ k_1\tau e^{-\beta_A t})
+\end{equation}
+
+\subsection{Mass Balance for $B$}
+
+For $B$, the initial concentration ($C_{B0}$) and inlet feed rate ($B_{IN}$) are both 0M. Therefore the mass balance is:
+\begin{equation}
+    \frac{dC_B}{dt} = \frac{-C_B}{\tau} + k_1C_A - k_2C_B
+\end{equation}
+We will now define $\beta_B = \frac{k_2\tau + 1}{\tau}$.
+The mass balance for $B$ can now be written as:
+\begin{equation}
+    \frac{dC_B}{dt} = -\beta_B C_B + k_1\alpha_A + k_1^2 \tau \alpha_A e^{-\beta_A t}
+\end{equation}
+Again the integrating factor method is used to solve for the transient profile of $B$: 
+\begin{align}
+    \frac{dC_B}{dt} + \beta_B C_B &=  k_1\alpha_A + k_1^2 \tau \alpha_A e^{-\beta_A t}\\
+    \frac{d}{dt}(C_B e^{\beta_B t}) &= k_1\alpha_A e^{\beta_B t} + k_1^2 \tau \alpha_A e^{(\beta_B-\beta_A) t}\\
+    C_B(t) &= \frac{k_1\alpha_A}{\beta_B} + \frac{k_1^2 \tau \alpha_A}{\beta_B - \beta_A} e^{-\beta_A t} + \gamma e^{-\beta_B t} 
+\end{align}
+Implementing the initial condition $C_{B0} = 0M$ and solving for $\gamma$, the resulting mass balance is 
+\begin{equation}
+    C_B(t) = \frac{k_1 \alpha_A}{\beta_B}(1-e^{-\beta_B t}) + \frac{k_1^2 \tau \alpha_A}{\beta_B - \beta_A} (e^{-\beta_A t} - e^{-\beta_B t})
+\end{equation}
+
+\newpage 
+\subsection{Mass Balance for $C$}
+
+Species $C$ is similar to $B$ in that the initial concentration ($C_{C0}$) and inlet feed rate ($C_{IN}$) are both 0M. 
+The mass balance is 
+\begin{align}
+    \frac{dC_c}{dt} &= \frac{-C_c}{\tau} + k_2 C_B\\
+    \frac{dC_C}{dt} + \frac{C_c}{\tau} &= k_2 C_B
+\end{align}
+Again the integrating factor method is used to solve the ODE:
+\begin{equation}
+    C_c e^{t/\tau} = \frac{k_2 k_1 \alpha_A}{\beta_B} \int dt e^{t/\tau} - e^{t(1/\tau - \beta_B)} + 
+        \frac{k_2 k_1^2 \tau \alpha_A}{\beta_B - \beta_A} \int dt e^{t (1/\tau - \beta_A)} - e^{t(1/\tau - \beta_B)} 
+\end{equation}
+After some trivial integration we have the mass balance:
+\begin{equation}
+    C_c(t) = \gamma e^{-t/\tau} + \frac{k_2 k_1 \alpha_A}{\beta_B}
+    \left(\tau - \frac{e^{-\beta_B}t}{1/\tau - \beta_B}\right) \frac{k_2 k_1^2 \tau \alpha_A}{\beta_B - \beta_A} 
+                \left(\frac{e^{-\beta_A t}}{1/\tau - \beta_A} - \frac{e^{-\beta_B t}}{1/\tau - \beta_B}\right)
+\end{equation}
+The constant of integration $\gamma$ is found through the initial condition $C_{C0} = 0$, yielding 
+\begin{equation}
+    \gamma = \frac{k_2 k_1 \alpha_A}{\beta_B}\left(\frac{1}{1/\tau - \beta_B} - \tau\right) + 
+        \frac{k_2 k_1^2 \tau \alpha_A}{\beta_B - \beta_A}\left(\frac{1}{1/\tau - \beta_B} - \frac{1}{1/\tau - \beta_A}\right)
+\end{equation}
+
+
+\section{Simulation Setup}
+
+Using the reaction system previously described, the following initial condtitions and inlet feed rates (``boundary conditions'') in units of [M] (concentration) employed for simulations are re-iterated here. 
+Note that the final transient profiles for all species were derived using these values and not for generalized (variable) conditions.
+\begin{align}
+	a_{BC} &= a_{IC} = 2\\
+	b_{BC} &= b_{IC} = 0\\
+	c_{BC} &= c_{IC} = 0
+\end{align}
+
+The solution vectors $sol^a$ (analytical) and $sol^n$ (\texttt{OpenCCM}) use the same specific timesteps given by the numerical solver.
+The error between these two solutions for a species computed at each timestep $i$ for $N$ total timesteps is a normalized absolute error:2
+\begin{equation}
+	err = \frac{\sum_i^N \lvert sol^a_i - sol^n_i \rvert}{N}
+\end{equation}
+
+\newpage
+Simulations were run using varying tolerances of 1e-3, 1e-7, 1e-10, and 1e-13 for both absolute and relative tolerances.
+Additionally, although stricter tolerances result in larger number of timesteps, this is accounted for in the error equation (normalization by $N$).
+
+\begin{figure}[H]
+    \includegraphics[width=0.49\linewidth]{tol_1e-03}\hfill
+    \includegraphics[width=0.49\linewidth]{tol_1e-07}
+\end{figure}
+\begin{figure}[H]
+    \includegraphics[width=0.49\linewidth]{tol_1e-10}\hfill
+    \includegraphics[width=0.49\linewidth]{tol_1e-13}
+\end{figure}
+
+\section{Conclusions}
+
+In conclusion:
+\begin{itemize}
+	\item \texttt{OpenCCM}'s CSTR implementation can handle irreversible linear reactions as validated by comparison to an analytically derived mass balance system.
+	\item Increasing the relative \& absolute simulation tolerances significantly reduces the overall error between analytical and numerical solutions.
+\end{itemize}
+
+\end{document}

--- a/examples/simple_reactors/cstr/irreversible/cstr_analysis.py
+++ b/examples/simple_reactors/cstr/irreversible/cstr_analysis.py
@@ -1,0 +1,107 @@
+########################################################################################################################
+# Copyright 2024 the authors (see AUTHORS file for full list).
+#
+#                                                                                                                    #
+# This file is part of OpenCCM.
+#
+#                                                                                                                    #
+# OpenCCM is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public
+#
+# License as published by the Free Software Foundation, either version 2.1 of the License, or (at your option) any  later version.                                                                                                       #
+#                                                                                                                    #
+# OpenCCM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.                                                                                                             #
+#                                                                                                                     #
+# You should have received a copy of the GNU Lesser General Public License along with OpenCCM. If not, see             #
+# <https://www.gnu.org/licenses/>.                                                                                     #
+########################################################################################################################
+
+import os 
+from pathlib import Path
+
+import numpy as np 
+import matplotlib.pyplot as plt 
+
+from openccm import run, ConfigParser
+
+# Reaction rate constants. NOTE: rate constants are not synced with reactions config (manual check is needed to ensure they are identical)
+k1 = 0.5 # hr^-1
+k2 = 0.2 # hr^-1
+tau = 10
+k1T = k1*tau
+
+# Ca(t) analytical
+Ca0 = 2 #mol/L the initial condition!
+betaA = (k1T + 1) / tau
+
+Ca_func = lambda t: (Ca0 / (1+k1T) ) * (1+ k1T*np.exp(-t*betaA))
+
+# Cb(t) analytical
+a1 = (k1*Ca0) / (k1T +1)
+a2 = a1 * k1T
+betaB = ((k2*tau) + 1) / tau
+
+Cb_func = lambda t: (a1/betaB) * (1-np.exp(-betaB*t)) + (a2/(betaB-betaA)) * (np.exp(-betaA*t) - np.exp(-betaB*t))
+
+# Cc(t) analytical
+F = lambda b: 1 / ( (1/tau) - b)
+A = (k2*a1/betaB)*(F(betaB)-tau) + (a2*k2/(betaB-betaA))*(F(betaB) - F(betaA))
+
+Cc_func = lambda t: A*np.exp(-t/tau) + (k2*a1/betaB)*(tau - F(betaB)*np.exp(-betaB*t)) + (a2*k2/(betaB-betaA))*( F(betaA)*np.exp(-betaA*t) - F(betaB)*np.exp(-betaB*t) )
+
+# Now get numerical results from openccm
+os.chdir(Path(__file__).parents[0])
+config_parser = ConfigParser('CONFIG')
+
+for tolerance in [1e-3, 1e-7, 1e-10, 1e-13]:
+	
+	# Runtime change of tolerance parameters regardless of what configuration file was given.
+	tolerance = '{:.0e}'.format(tolerance)
+	config_parser['SIMULATION']['atol'] = tolerance
+	config_parser['SIMULATION']['rtol'] = tolerance
+	run(config_parser)
+	
+	# get openccm results for c and t vectors
+	outputs = os.listdir(os.getcwd()+'/output_ccm')
+	t_vec = np.load(os.getcwd()+'/output_ccm/cstr_t.npy')
+	c_vec = np.load(os.getcwd()+'/output_ccm/cstr_concentrations.npy')
+	c_vec = np.squeeze(c_vec) # remove DOF (just 1 for CSTR)
+
+	# error computation
+	err_func = lambda an, num: np.sum(abs(an-num)) / len(t_vec)
+
+	# organize results, use same time domain points as openccm for error calculation purposes
+	Ca_analytical = Ca_func(t_vec)
+	Ca_openccm = c_vec[0]
+	Ca_err = err_func(Ca_analytical, Ca_openccm)
+
+	Cb_analytical = Cb_func(t_vec)
+	Cb_openccm = c_vec[1]
+	Cb_err = err_func(Cb_analytical, Cb_openccm)
+
+	Cc_analytical = Cc_func(t_vec)
+	Cc_openccm = c_vec[2]
+	Cc_err = err_func(Cc_analytical, Cc_openccm)
+
+	# Plot all results
+	plt.figure()
+	textstr = '\n'.join(("err [A] = {:0.3e}".format(Ca_err),
+						 "err [B] = {:0.3e}".format(Cb_err),
+						 "err [C] = {:0.3e}".format(Cc_err)))
+
+	plt.plot(t_vec, Ca_analytical, color='r', label='[A] analytical')
+	plt.scatter(t_vec, Ca_openccm, s=8, color='r', label='[A] openccm')
+
+	plt.plot(t_vec, Cb_analytical, color='b', label='[B] analytical')
+	plt.scatter(t_vec, Cb_openccm, s=8, color='b', label='[B] openccm')
+
+	plt.plot(t_vec, Cc_analytical, color='g', label='[C] analytical')
+	plt.scatter(t_vec, Cc_openccm, s=8, color='g', label='[C] openccm')
+
+	plt.xlabel('Time [hr]')
+	plt.ylabel('Concentration [M]')
+	plt.title(f'rtol & atol = {tolerance}')
+
+	plt.text(1.5,1.5,textstr)
+	plt.legend()
+	plt.savefig(f"analysis/tol_{tolerance}.pdf")
+	#plt.show()

--- a/examples/simple_reactors/cstr/irreversible/reactions
+++ b/examples/simple_reactors/cstr/irreversible/reactions
@@ -1,0 +1,8 @@
+[REACTIONS]
+R1: a -> b
+R2: b -> c
+
+[RATES]
+R1: 0.5
+R2: 0.2
+

--- a/examples/simple_reactors/cstr/reversible/CONFIG
+++ b/examples/simple_reactors/cstr/reversible/CONFIG
@@ -1,0 +1,35 @@
+[INPUT]
+opencmp_config_file_path    = ../../fake_sim_input/config_hydrodynamics
+opencmp_sol_file_path       = ../../fake_sim_input/output/ins_sol/ins_0.0.sol
+num_refinements             = 0
+min_magnitude_threshold     = 6e-5
+
+no_flux_names       = None
+ignored_names       = ("top", "bottom")
+domain_inlet_names  = ("left",)
+domain_outlet_names = ("right",)
+
+[COMPARTMENTALIZATION]
+min_compartment_size = 0.999
+bc_names_for_seeds  = ("left",)
+
+[COMPARTMENT MODELLING]
+model = CSTR
+
+[SIMULATION]
+run                 = True
+rtol                = 1e-13
+atol				= 1e-13
+t_span              = 0, 70
+specie_names        = a, b
+reactions_file_path = reactions
+initial_conditions  = a -> 0
+                      b -> 0
+boundary_conditions = a: left -> 1
+                      b: left -> 0
+
+[POST-PROCESSING]
+inlet_bc_name          = left
+outlet_bc_name         = right
+output_VTK             = True
+

--- a/examples/simple_reactors/cstr/reversible/analysis.tex
+++ b/examples/simple_reactors/cstr/reversible/analysis.tex
@@ -1,0 +1,190 @@
+\documentclass[a4paper,12pt]{article}
+\usepackage[margin=0.65in]{geometry}
+\usepackage{amsmath,amssymb,amstext}
+\usepackage[hidelinks]{hyperref}
+\usepackage{graphicx}
+\usepackage{float}
+
+\usepackage{setspace}
+\setlength{\parskip}{0.65cm}
+\singlespacing
+
+\setlength{\parindent}{0cm}
+
+\begin{document}
+
+\title{\texttt{OpenCCM} CSTR Validation: Reversible Linear Reaction}
+\author{Matthew Peres Tino}
+\maketitle
+
+\section{Reaction System}
+
+Suppose we have the following reversible linear reaction:
+\begin{center}
+	$A\xrightarrow[]{k_f} B$
+	
+	$B\xrightarrow[]{k_r} A$
+\end{center}
+
+The reaction rates are easily derived, and are as follows:
+\begin{align}
+    r_A &= k_rB - k_fA \\
+    r_B &= k_fA - k_rB 
+\end{align}
+Herein, for a chemical species $P$, the concentration at a given time (i.e. $[P]$ or $C_P(t)$) will be noted as just $P$ for brevity.
+
+\section{CSTR Mass Balance}
+
+A transient mass balance for a species $P$ in a CSTR is as follows. 
+\begin{align}
+    \frac{dN_P}{dt} &= F_{in} - F_{out} + Vr_P\\
+    V\frac{dP}{dt} &= Q P_{IN} - QP + Vr_P \\
+    \frac{dP}{dt} &= \frac{P_{IN}}{\tau} - \frac{P}{\tau} + r_P
+\end{align}
+where $N_P$ is the number of moles, $F$ represents the molar flow rate in $mol/s$, $V$ is the volume of the CSTR, $r_P$ is the reaction rate, and $P$ and $P_{IN}$ represent the concentration of species $P$ and the inlet feed rate (which plays the role of a ``boundary condition''), respectively.
+Solving for constant volume $V$ and volumetric feed rate $Q$ allows for simplifications as shown above, where $\tau = \frac{V}{Q}$.
+
+\newpage 
+\subsection{Mass Balance System}
+Using the formula above, the mass balance for species $A$ is: 
+\begin{equation}
+    \frac{dA}{dt} = \alpha A + k_r B + \frac{A_{IN}}{\tau}
+\end{equation}
+where $\alpha = -k_f - 1/\tau$, and $A_{IN}$ represents the ``boundary condition'' (constant inlet feed rate) for species $A$. 
+
+Similarly the mass balance for species $B$ is:
+\begin{equation}
+    \frac{dB}{dt} = k_f A + \beta B + \frac{B_{IN}}{\tau}
+\end{equation}
+where $\beta = -k_r - 1/\tau$, and $B_{IN}$ represents the ``boundary condition'' (constant inlet feed rate) for species $B$. 
+
+This is a coupled linear system of inhomogeneous ODEs.
+By recognizing that $r_A = -r_B$, this allows for a simplified total conservation of mass expression that is easy to solve analytically.
+
+We begin by noting the following definitions:
+\begin{align}
+    C(t) &= A(t) + B(t)\\
+    C_{IN} &= A_{IN} + B_{IN}\\
+    C_0 &= A_0 + B_0
+\end{align}
+Now finding an expression for transient conservation of mass:
+\begin{align}
+    \frac{dC}{dt} &= \alpha A + k_r B + \frac{A_{IN}}{\tau} + k_f A + \beta B + \frac{B_{IN}}{\tau}\\
+    &= (\alpha + k_f)A + (\beta + k_r)B + \frac{A_{IN} + B_{IN}}{\tau}\\
+    &= \frac{-C}{\tau} + \frac{C_{IN}}{\tau}
+\end{align}
+This equation is ideal for use of the integrating factor method to generate a general solution for $C(t)$:
+\begin{align}
+    \frac{dC}{dt} + \frac{C}{\tau} &= \frac{C_{IN}}{\tau}\\
+    \frac{d}{dt}(Ce^{t/\tau}) &=\frac{C_{IN}}{\tau} e^{t/\tau}\\
+    Ce^{t/\tau} &= \int \frac{C_{IN}}{\tau} e^{t/\tau} dt\\
+    Ce^{t/\tau} &= C_{IN}e^{t/\tau} + \gamma\\
+    C(t) &= C_{IN} + \gamma  e^{-t/\tau}
+\end{align}
+Using a generalized initial condition $C(t=0) = C_0 = C_{IN} + \gamma$, we find that $\gamma = C_0 - C_{IN}$.
+We now have $C(t)$ in its final form:
+\begin{equation}
+    C(t) = C_{IN} + (C_0 - C_{IN}) e^{-t/\tau}
+\end{equation}
+Returning to the governing ODE for species $A$ and inserting $B = C-A$, we have:
+\begin{align}
+    A' &= \alpha A + k_r (C-A) + \frac{A_{IN}}{\tau}\\
+    &= (\alpha- k_r)A + k_r C + \frac{A_{IN}}{\tau}
+\end{align}
+We now define some simplifications,
+\begin{align}
+    \alpha^* &= k_r - \alpha = k_r + k_f + \frac{1}{\tau}\\
+    f(t) &= k_r C_{IN} + k_r(C_0 - C_{IN}) e^{-t/\tau} + \frac{A_{IN}}{\tau}
+\end{align}
+of which now we can define our new governing ODE for species $A$:
+\begin{equation}
+    A' + \alpha^* A = f(t)
+\end{equation}
+Again, this suggests use of the integrating factor method to obtain the general solution for $A(t)$:
+\begin{align}
+    \frac{d}{dt}(Ae^{\alpha^* t}) &= f(t)e^{\alpha^* t}\\
+    Ae^{\alpha^* t} &= \int f(t)e^{\alpha^* t} dt\\
+    &= \int \left(k_r C_{IN} + \frac{A_{IN}}{\tau}\right)e^{\alpha^* t} + k_r(C_0 - C_{IN}) e^{t(\alpha^* - 1/\tau)} dt\\
+    &= \frac{\left(k_r C_{IN} + A_{IN}/\tau\right)}{\alpha^*}e^{\alpha^* t} + 
+        \frac{k_r(C_0 - C_{IN}) e^{t(\alpha^* - 1/\tau)}}{\alpha^* - 1/\tau} + \omega\\
+    \rightarrow A(t) &= \frac{\left(k_r C_{IN} + A_{IN}/\tau\right)}{\alpha^*} + 
+        \frac{k_r(C_0 - C_{IN}) e^{-t/\tau}}{\alpha^* - 1/\tau} + \omega e^{-\alpha^* t}
+\end{align}
+Inserting the general initial condition, $A(t=0) = A_0$, we solve for the constant $\omega$:
+\begin{align}
+    A(0) &= A_0\\
+    A(0) &= \frac{\left(k_r C_{IN} + A_{IN}/\tau\right)}{\alpha^*} + \frac{k_r(C_0 - C_{IN})}{\alpha^* - 1/\tau} + \omega \\
+    \rightarrow \omega &= A_0 - \frac{\left(k_r C_{IN} + A_{IN}/\tau\right)}{\alpha^*} - \frac{k_r(C_0 - C_{IN})}{\alpha^* - 1/\tau}
+\end{align}
+At last we arrive at the complete expression for $A(t)$:
+\begin{equation}
+    A(t) = A_0e^{-\alpha^* t} + \frac{\left(k_r C_{IN} + A_{IN}/\tau\right)}{\alpha^*}\left(1-e^{-\alpha^* t}\right) + 
+    \frac{k_r(C_0 - C_{IN})}{\alpha^* - 1/\tau}\left(e^{-t/\tau}-e^{-\alpha^* t}\right)
+\end{equation}
+
+\newpage 
+
+\section{Simulation Setup}
+
+Using the reaction system previously described, the following describes initial conditions and inlet feed rates (``boundary conditions'') in units of [M] (concentration) that were employed for simulations. 
+\begin{align}
+	A_{0} &= 0\\
+    B_{0} &= 0\\
+	A_{IN} &= 1\\
+    B_{IN} &= 0
+\end{align}
+This setup represents a CSTR with no initial chemical species present but includes a constant inlet feed rate (boundary condition) of 1M for species $A$ which will induce reaction behaviour as time evolves. 
+
+The solution vectors $sol^a$ (analytical) and $sol^n$ (\texttt{OpenCCM}) use the same specific timesteps given by the numerical solver.
+The error between these two solutions for a species computed at each timestep $i$ for $N$ total timesteps is a normalized absolute error:
+\begin{equation}
+	err = \frac{\sum_i^N \lvert sol^a_i - sol^n_i \rvert}{N}
+\end{equation}
+
+
+\subsection{Simulation for Small $k$}
+
+Simulations were run using varying tolerances of 1e-3, 1e-7, 1e-10, and 1e-13 for both absolute and relative tolerances using the following $k$ values (units of $s^{-1}$):
+\begin{align}
+    k_f &= 1 \times 10^{-2}\\
+    k_r &= 1 \times 10^{-4}
+\end{align}
+Note that these constants were chosen arbitrarily to represent a system with dominant $A$ concentration over $B$ production. 
+Additionally, although stricter tolerances result in larger number of simulation timesteps, this is accounted for in the error equation (normalization by $N$).
+\begin{figure}[H]
+    \includegraphics[width=0.49\linewidth]{tol_1e-03_kr_1e-04_kf_1e-02}\hfill
+    \includegraphics[width=0.49\linewidth]{tol_1e-07_kr_1e-04_kf_1e-02}
+\end{figure}
+\begin{figure}[H]
+    \includegraphics[width=0.49\linewidth]{tol_1e-10_kr_1e-04_kf_1e-02}\hfill
+    \includegraphics[width=0.49\linewidth]{tol_1e-13_kr_1e-04_kf_1e-02}
+\end{figure}
+
+\subsection{Simulation for Large $k$}
+
+Simulations were run using varying tolerances of 1e-3, 1e-7, 1e-10, and 1e-13 for both absolute and relative tolerances using the following $k$ values (units of $s^{-1}$):
+\begin{align}
+    k_f &= 1\\
+    k_r &= 1
+\end{align}
+Note that these constants were chosen arbitrarily to represent a system with near-equal steady state $A$ and $B$ concentrations. 
+Additionally, although stricter tolerances result in larger number of simulation timesteps, this is accounted for in the error equation (normalization by $N$).
+\begin{figure}[H]
+    \includegraphics[width=0.49\linewidth]{tol_1e-03_kr_1e+00_kf_1e+00}\hfill
+    \includegraphics[width=0.49\linewidth]{tol_1e-07_kr_1e+00_kf_1e+00}
+\end{figure}
+\begin{figure}[H]
+    \includegraphics[width=0.49\linewidth]{tol_1e-10_kr_1e+00_kf_1e+00}\hfill
+    \includegraphics[width=0.49\linewidth]{tol_1e-13_kr_1e+00_kf_1e+00}
+\end{figure}
+
+\section{Conclusions}
+
+In conclusion:
+\begin{itemize}
+	\item \texttt{OpenCCM}'s CSTR implementation can handle linear reversible reactions, both for relatively small or large $k$ rate constants, as validated by comparison to an analytically derived mass balance system.
+	\item Increasing the relative \& absolute simulation tolerances significantly reduces the overall error between analytical and numerical solutions.
+\end{itemize}
+
+
+\end{document}

--- a/examples/simple_reactors/cstr/reversible/cstr_analysis.py
+++ b/examples/simple_reactors/cstr/reversible/cstr_analysis.py
@@ -1,0 +1,102 @@
+########################################################################################################################
+# Copyright 2024 the authors (see AUTHORS file for full list).
+#
+#                                                                                                                    #
+# This file is part of OpenCCM.
+#
+#                                                                                                                    #
+# OpenCCM is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public
+#
+# License as published by the Free Software Foundation, either version 2.1 of the License, or (at your option) any  later version.                                                                                                       #
+#                                                                                                                    #
+# OpenCCM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.                                                                                                             #
+#                                                                                                                     #
+# You should have received a copy of the GNU Lesser General Public License along with OpenCCM. If not, see             #
+# <https://www.gnu.org/licenses/>.                                                                                     #
+########################################################################################################################
+
+import os 
+from pathlib import Path
+
+import numpy as np 
+import matplotlib.pyplot as plt 
+
+from openccm import run, ConfigParser
+
+# Reaction rate constants. NOTE: rate constants are not synced with reactions config (manual check is needed to ensure they are identical)
+# for large k:
+kf = 1 # s^-1
+kr = 1 # s^-1
+# for small k:
+# kf = 1e-2
+# kr = 1e-4 
+
+# Initial and "boundary" conditions (inlet feed rates)
+tau = 10
+a0, b0 = 0, 0
+aIN, bIN = 1, 0
+
+# Let C be the total mass, C = A+B.
+c0 = a0 + b0
+cIN = aIN + bIN
+
+# Useful constants based on hand written derivation
+alpha = -kf - 1/tau 
+alphaSTAR = kr + kf + 1/tau
+omega = a0 - (kr*cIN + aIN/tau)/alphaSTAR - kr*(c0-cIN)/(kr+kf)
+
+# Define analytical solutions
+A_t = lambda t: omega*np.exp(-alphaSTAR*t) + kr*(c0-cIN)*np.exp(-t/tau)/(kr + kf) + (kr*cIN + aIN/tau)/alphaSTAR
+
+C_t = lambda t: cIN + (c0 - cIN)*np.exp(-t/tau)
+
+B_t = lambda t: C_t(t) - A_t(t)
+
+# Now get numerical results from openccm
+os.chdir(Path(__file__).parents[0])
+config_parser = ConfigParser('CONFIG')
+
+for tolerance in [1e-3, 1e-7, 1e-10, 1e-13]:
+	
+	# Runtime change of tolerance parameters regardless of what configuration file was given.
+	tolerance = '{:.0e}'.format(tolerance)
+	config_parser['SIMULATION']['atol'] = tolerance
+	config_parser['SIMULATION']['rtol'] = tolerance
+	run(config_parser)
+	
+	# get openccm results for c and t vectors
+	outputs = os.listdir(os.getcwd()+'/output_ccm')
+	t_vec = np.load(os.getcwd()+'/output_ccm/cstr_t.npy')
+	c_vec = np.load(os.getcwd()+'/output_ccm/cstr_concentrations.npy')
+	c_vec = np.squeeze(c_vec) # remove DOF (just 1 for CSTR)
+
+	# error computation
+	err_func = lambda an, num: np.sum(abs(an-num)) / len(t_vec)
+
+	# organize results, use same time domain points as openccm for error calculation purposes
+	A_analytical = A_t(t_vec)
+	A_openccm = c_vec[0]
+	A_error = err_func(A_analytical, A_openccm)
+
+	B_analytical = B_t(t_vec)
+	B_openccm = c_vec[1]
+	B_error = err_func(B_analytical, B_openccm)
+
+	# Plot all results
+	plt.figure()
+	textstr = '\n'.join(("err [A] = {:0.3e}".format(A_error),
+						 "err [B] = {:0.3e}".format(B_error)))
+	plt.text(9,0.2,textstr)
+
+	plt.plot(t_vec, A_analytical, color='r', label='[A] analytical')
+	plt.scatter(t_vec, A_openccm, s=8, color='r', label='[A] openccm')
+
+	plt.plot(t_vec, B_analytical, color='b', label='[B] analytical')
+	plt.scatter(t_vec, B_openccm, s=8, color='b', label='[B] openccm')
+
+	plt.xlabel('Time [s]')
+	plt.ylabel('Concentration [M]')
+	plt.title(f'(kf, kr) = ({kf:1.0e}, {kr:1.0e}) | rtol & atol={tolerance}')
+	plt.legend()
+	plt.savefig(f"analysis/tol_{tolerance}_kr_{kr:1.0e}_kf_{kf:1.0e}.png")
+	#plt.show()

--- a/examples/simple_reactors/cstr/reversible/reactions
+++ b/examples/simple_reactors/cstr/reversible/reactions
@@ -1,0 +1,8 @@
+[REACTIONS]
+R1: a -> b
+R2: b -> a
+
+[RATES]
+R1: 1
+R2: 1
+

--- a/examples/simple_reactors/pfr/CONFIG
+++ b/examples/simple_reactors/pfr/CONFIG
@@ -1,0 +1,34 @@
+[INPUT]
+opencmp_config_file_path    = ../fake_sim_input/config_hydrodynamics
+opencmp_sol_file_path       = ../fake_sim_input/output/ins_sol/ins_0.0.sol
+num_refinements             = 0
+min_magnitude_threshold     = 6e-5
+
+no_flux_names       = None
+ignored_names       = ("top", "bottom")
+domain_inlet_names  = ("left",)
+domain_outlet_names = ("right",)
+
+[COMPARTMENTALIZATION]
+bc_names_for_seeds  = ("left",)
+min_compartment_size = 0.999
+
+[COMPARTMENT MODELLING]
+model = PFR
+
+[SIMULATION]
+run                 = True
+t_span              = 0, 20
+points_per_pfr      = 101
+specie_names        = a, b
+reactions_file_path = reactions
+initial_conditions  = a -> 0
+                      b -> 0
+boundary_conditions = a: left -> H(100*t)
+                      b: left -> 0
+
+[POST-PROCESSING]
+inlet_bc_name          = left
+outlet_bc_name         = right
+output_VTK             = False
+network_diagram        = False

--- a/examples/simple_reactors/pfr/analysis.tex
+++ b/examples/simple_reactors/pfr/analysis.tex
@@ -13,13 +13,13 @@
 
 \begin{document}
 
-\title{\texttt{OpenCCM} PFR Validation: Irreversible Nonlinear Reaction}
+\title{\texttt{OpenCCM} PFR Validation: Irreversible Linear Reaction}
 \author{Matthew Peres Tino}
 \maketitle
 
 \section{Reaction System}
 
-Suppose we have the following irreversible nonlinear reaction:
+Suppose we have the following irreversible linear reaction:
 \begin{center}
 	$a\xrightarrow[]{k} 2b$
 \end{center}
@@ -241,7 +241,7 @@ The error between these two solutions for a species computed at each timestep $i
 
 In conclusion:
 \begin{itemize}
-	\item \texttt{OpenCCM}'s PFR implementation can handle nonlinear irreversible reactions as validated by comparison to an analytically derived mass balance system. 
+	\item \texttt{OpenCCM}'s PFR implementation can handle linear irreversible reactions as validated by comparison to an analytically derived mass balance system. 
 	\item Increasing the PFR discretization points marginally affected the order of magnitude for the error (however, it still decreased the error as expected). 
 	\item This is not a significant result compared to the change in error observed from decreasing relative/absolute tolerances in the various CSTR validations. 
 \end{itemize}

--- a/examples/simple_reactors/pfr/analysis.tex
+++ b/examples/simple_reactors/pfr/analysis.tex
@@ -1,0 +1,249 @@
+\documentclass[a4paper,12pt]{article}
+\usepackage[margin=0.65in]{geometry}
+\usepackage{amsmath,amssymb,amstext, mathrsfs}
+\usepackage[hidelinks]{hyperref}
+\usepackage{graphicx}
+\usepackage{float}
+
+\usepackage{setspace}
+\setlength{\parskip}{0.65cm}
+\singlespacing
+
+\setlength{\parindent}{0cm}
+
+\begin{document}
+
+\title{\texttt{OpenCCM} PFR Validation: Irreversible Nonlinear Reaction}
+\author{Matthew Peres Tino}
+\maketitle
+
+\section{Reaction System}
+
+Suppose we have the following irreversible nonlinear reaction:
+\begin{center}
+	$a\xrightarrow[]{k} 2b$
+\end{center}
+where $k = 0.1$ $s^{-1}$.
+Herein, for a chemical species $p$, the concentration at a given time (i.e. $[p]$ or $C_p(t)$) will be noted as just $p$ for brevity.
+
+The reaction rates are easily derived, and are as follows:
+\begin{align}
+    r_a &= -k a \\
+    r_b &= 2 k a
+\end{align}
+
+\section{PFR Mass Balance}
+
+A transient mass balance for a species $p$ in a PFR is as follows. 
+\begin{equation}
+	\frac{\partial p}{\partial t} = -Q\frac{\partial p}{\partial V} + r_p
+\end{equation}
+where $Q$ is the volumetric feed rate.
+This formula will be used to solve the coupled partial differential equation system for species $a$ and $b$. 
+
+\newpage 
+\subsection{Mass Balance for $a$}
+
+The mass balance for species $a$ is 
+\begin{equation}
+	\frac{\partial a}{\partial t} = -Q\frac{\partial a}{\partial V} + -ka
+\end{equation}
+we will use generic boundary and initial conditions, i.e.
+\begin{align}
+	a(0, t) &= a_{BC}\\
+	a(V, 0) &= a_{IC} 
+\end{align}
+We will make good use of the Laplace transform ($\mathscr{L}$).
+Applying the Laplace transform on our transient function $a$ yields $ \mathscr{L}\{a(V, t)\} = A(V, s) $.
+Applying the Laplace transform on the governing PDE we obtain 
+\begin{equation}
+	sA(V,s) - a_{IC} = -Q\frac{\partial A}{\partial V} - kA(V,s)
+\end{equation}
+This equation can be re-written in a convenient form to use the integrating factor method:
+\begin{equation}
+	\left( \frac{s+k}{Q} \right) A + \frac{\partial A}{\partial V} = \frac{a_{IC}}{Q}
+\end{equation}
+
+Using the integrating factor method, this ODE is easily solved:
+\begin{align}
+	\frac{\partial A}{\partial V}\left( Ae^{(s+k)V/Q} \right) &= \frac{a_{IC}}{Q} e^{(s+k)V/Q}\\
+	Ae^{(s+k)V/Q} &= \left( \frac{a_{IC}}{s+k}\right)e^{(s+k)V/Q}  + \alpha\\
+	A(V, s) &= \frac{a_{IC}}{s+k} + \alpha e^{-(s+k)V/Q}
+\end{align}
+Converting the boundary condition using the Laplace transform yields $ A(0, s) = \frac{a_{BC}}{s} $.
+Now implementing this BC we have 
+\begin{align}
+	A(0, s) &= \frac{a_{IC}}{s+k} + \alpha \\
+	A(0, s) &= \frac{a_{BC}}{s} \\
+	\rightarrow \alpha &= \frac{a_{BC}}{s} - \frac{a_{IC}}{s+k}
+\end{align}
+And thus we have the final form for species $a$ in the Laplace domain:
+\begin{equation}
+	A(V, s) = \frac{a_{IC}}{s+k} + \left( \frac{a_{BC}}{s} \right)e^{-(s+k)V/Q} - 
+			\left( \frac{a_{IC}}{s+k} \right)e^{-(s+k)V/Q}
+\end{equation}
+
+Before inverting this expression, we note the following rules of the inverse Laplace transform:
+\begin{align}
+	\mathscr{L}^{-1} \left\{ \frac{1}{s-a} \right\} &= e^{at} \\
+	\mathscr{L}^{-1} \left\{ \frac{e^{-ps}}{s+m} \right\} &= H(t-p) e^{-m(t-p)}
+\end{align}
+where $H(t)$ denotes the \emph{Heaviside} function (or unit step function).
+
+Using these rules, we can easily invert the $A(V, s)$ expression to obtain the time domain solution for $a(V,t)$:
+\begin{equation}
+	a(V, t) = a_{IC} e^{-kt} + a_{BC}e^{-kV/Q}H(t-V/Q) - a_{IC} H(t-V/Q) e^{-kt}
+\end{equation}
+which can also be simplified to yield
+\begin{equation}
+	a(V, t) = a_{IC} e^{-kt}(1-H(t-V/Q)) + a_{BC}e^{-kV/Q}H(t-V/Q)
+\end{equation}
+
+\subsection{Mass Balance for $b$}
+
+The mass balance for species $b$ is 
+\begin{equation}
+	\frac{\partial b}{\partial t} = -Q\frac{\partial b}{\partial V} + +2ka
+\end{equation}
+and again, we will use generic boundary and initial conditions, i.e.
+\begin{align}
+	b(0, t) &= b_{BC}\\
+	b(V, 0) &= b_{IC} 
+\end{align}
+The Laplace transform ($\mathscr{L}$) is used on the function $b$, i.e. $ \mathscr{L}\{b(V, t)\} = B(V, s) $.
+Applying the Laplace transform on the governing PDE we obtain 
+\begin{equation}
+	sB(V,s) - b_{IC} = -Q\frac{\partial B}{\partial V} + 2kA(V,s)
+\end{equation}
+Again, this equation can be re-written in a convenient form to use the integrating factor method:
+\begin{equation}
+	\left( \frac{s}{Q} \right) B + \frac{\partial B}{\partial V} = \frac{2kA}{Q} + \frac{b_{IC}}{Q}
+\end{equation}
+Using the integrating factor method:
+\begin{equation}
+	e^{sV/Q}B = \frac{2k}{Q} \underbrace{ \int Ae^{sV/Q} dV}_{I_1}
+					+ \frac{b_{IC}}{Q} \int e^{sV/Q} dV
+\end{equation}
+Solving $I_1$:
+\begin{equation}
+	Ae^{sV/Q} = \left( \frac{a_{IC}}{s+k}\right) e^{sV/Q} +
+				\left( \frac{a_{BC}}{s}\right) e^{-kV/Q}  - 
+				\left( \frac{a_{IC}}{s+k}\right) e^{-kV/Q} 
+\end{equation}
+Integrating over all $V$ yields 
+\begin{equation}
+	\int Ae^{sV/Q} dV = \left( \frac{a_{IC}}{s+k}\right) \left( \frac{Q}{s}\right) e^{sV/Q} +
+						f(V) \left( \frac{a_{BC}}{s} - \frac{a_{IC}}{s+k} \right)
+\end{equation}
+where
+\begin{equation}
+	f(V) = \left( \frac{-Q}{k} \right) e^{-kV/Q}
+\end{equation}
+
+\newpage
+Returning to the expression for $B(V, s)$:
+\begin{equation}
+	e^{sV/Q}B = \left( \frac{2ka_{IC}}{s (s+k)} \right) e^{sV/Q} + 
+				\left( \frac{2k}{Q} \right)f(V) \left( \frac{a_{BC}}{s} - \frac{a_{IC}}{s+k} \right) +
+				\left( \frac{b_{IC}}{s}  \right) e^{sV/Q} + \beta
+\end{equation}
+where $\beta$ is the constant of integration. 
+Simplifying to solve for $B(V, s)$ yields
+\begin{equation}
+	B(V, s) = \frac{2ka_{IC}}{s (s+k)} + 
+		\left( \frac{2k}{Q} \right)f(V) \left( \frac{a_{BC}}{s} - \frac{a_{IC}}{s+k} \right) e^{-sV/Q} +
+		\frac{b_{IC}}{s} + \beta e^{-sV/Q}
+\end{equation}
+Converting the boundary condition using the Laplace transform yields $ B(0, s) = \frac{b_{BC}}{s} $.
+Now implementing this BC we have 
+\begin{align}
+	B(0, s) &= \frac{2ka_{IC}}{s (s+k)} + 
+	\left( \frac{2k}{Q} \right)f(0) \left( \frac{a_{BC}}{s} - \frac{a_{IC}}{s+k} \right) +
+	\frac{b_{IC}}{s} + \beta \\
+	B(0, s) &= \frac{b_{BC}}{s} \\
+	\rightarrow \beta &= \frac{b_{BC} - b_{IC}}{s} - \frac{2ka_{IC}}{s (s+k)} + 
+	2 \left( \frac{a_{BC}}{s} - \frac{a_{IC}}{s+k} \right)
+\end{align}
+
+We now begin the tedious task of inverting the $B(V, s)$ solution.
+It is first important to note an incredibly useful simplification,
+\begin{equation}
+	\frac{1}{s(s+k)} = \left(\frac{1}{k}\right) \left(\frac{1}{s} - \frac{1}{s+k}\right)
+\end{equation}
+
+We begin by inverting the term with $\beta$, 
+\begin{align}
+	\beta e^{-sV/Q}  &= \left( \frac{b_{BC} - b_{IC}}{s} \right) e^{-sV/Q} - 
+						2a_{IC} \left(\frac{1}{s} - \frac{1}{s+k}\right) e^{-sV/Q}\\
+						&+  2 \left( \frac{a_{BC}}{s} - \frac{a_{IC}}{s+k} \right) e^{-sV/Q}\\
+	\mathscr{L}^{-1} \left\{ \beta e^{-sV/Q} \right\} &= (b_{BC}-b_{IC})H(t-V/Q) - 
+					2a_{IC}H(t-V/Q)(1-e^{-k(t-V/Q)})\\
+					&+ 2H(t-V/Q)(a_{BC} - a_{IC}e^{-k(t-V/Q)})\\
+					&= (b_{BC}-b_{IC})H(t-V/Q) + 2H(t-V/Q) (a_{BC}-a_{IC})
+\end{align}
+
+putting this together with the remaining terms, we have 
+\begin{align}
+	b(V, t) &= 2a_{IC} (1-e^{-kt}) - 2e^{-kV/Q}H(t-V/Q) \left( a_{BC} - a_{IC}e^{-k(t-V/Q)} \right)\\
+			&+ b_{IC} + (b_{BC}-b_{IC})H(t-V/Q) + 2H(t-V/Q) (a_{BC}-a_{IC})
+\end{align}
+and after some simplifications, we finally have the time domain expression for species $b$:
+\begin{align}
+	b(V, t) &= 2a_{IC} \left(1-H(t-V/Q)\right) \left(1-e^{-kt}\right) \\
+				&+ 2 a_{BC} H(t-V/Q) (1-e^{-kV/Q}) \\
+				&+ (b_{BC} - b_{IC}) H(t-V/Q) + b_{IC}
+\end{align}
+
+\section{Simulation Setup}
+
+Using the reaction system previously described, the following boundary and initial conditions were used for simulations. 
+\begin{align}
+	a(0, t) &= a_{BC} = 1\\
+	a(V, 0) &= a_{IC} = 0\\
+	b(0, t) &= b_{BC} = 0\\
+	b(V, 0) &= b_{IC} = 0
+\end{align}
+
+Using these values, the mass balance equations simplify to 
+\begin{align}
+	a(V, t) &= e^{-kV/Q}H(t-V/Q)\\
+	b(V, t) &= 2 H(t-V/Q) (1-e^{-kV/Q}) 
+\end{align}
+
+Simulations were performed in a PFR discretized at 21, 101, and 501 points in the volume domain. 
+Analytical and numerical (\texttt{OpenCCM}) results were compared at the inlet, midpoint, and outlet volume points. 
+
+The solution vectors $sol^a$ (analytical) and $sol^n$ (\texttt{OpenCCM}) use the same specific timesteps given by the numerical solver.
+The error between these two solutions for a species computed at each timestep $i$ for $N$ total timesteps is a normalized absolute error:
+\begin{equation}
+	err = \frac{\sum_i^N \lvert sol^a_i - sol^n_i \rvert}{N}
+\end{equation}
+
+\begin{figure}[H] % 21 points
+    \includegraphics[width=0.33\linewidth]{inlet_21_points}\hfill
+    \includegraphics[width=0.33\linewidth]{midpoint_21_points}\hfill
+    \includegraphics[width=0.33\linewidth]{outlet_21_points}
+\end{figure}
+\vspace{-10pt}
+\begin{figure}[H] % 101 points
+    \includegraphics[width=0.33\linewidth]{inlet_101_points}\hfill
+    \includegraphics[width=0.33\linewidth]{midpoint_101_points}\hfill
+    \includegraphics[width=0.33\linewidth]{outlet_101_points}
+\end{figure}
+\vspace{-10pt}
+\begin{figure}[H] % 501 points
+    \includegraphics[width=0.33\linewidth]{inlet_501_points}\hfill
+    \includegraphics[width=0.33\linewidth]{midpoint_501_points}\hfill
+    \includegraphics[width=0.33\linewidth]{outlet_501_points}
+\end{figure}
+
+\section{Conclusions}
+
+In conclusion:
+\begin{itemize}
+	\item \texttt{OpenCCM}'s PFR implementation can handle nonlinear irreversible reactions as validated by comparison to an analytically derived mass balance system. 
+	\item Increasing the PFR discretization points marginally affected the order of magnitude for the error (however, it still decreased the error as expected). 
+	\item This is not a significant result compared to the change in error observed from decreasing relative/absolute tolerances in the various CSTR validations. 
+\end{itemize}
+
+\end{document}

--- a/examples/simple_reactors/pfr/pfr_analysis.py
+++ b/examples/simple_reactors/pfr/pfr_analysis.py
@@ -1,0 +1,172 @@
+########################################################################################################################
+# Copyright 2024 the authors (see AUTHORS file for full list).
+#
+#                                                                                                                    #
+# This file is part of OpenCCM.
+#
+#                                                                                                                    #
+# OpenCCM is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public
+#
+# License as published by the Free Software Foundation, either version 2.1 of the License, or (at your option) any  later version.                                                                                                       #
+#                                                                                                                    #
+# OpenCCM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.                                                                                                             #
+#                                                                                                                     #
+# You should have received a copy of the GNU Lesser General Public License along with OpenCCM. If not, see             #
+# <https://www.gnu.org/licenses/>.                                                                                     #
+########################################################################################################################
+
+import os 
+from pathlib import Path
+
+import numpy as np 
+from numpy import heaviside as HV
+import matplotlib.pyplot as plt
+from matplotlib import animation
+
+from openccm import run, ConfigParser
+
+# Save movie (transient solution simulation)?
+save_movie = False
+
+Path('analysis').mkdir(parents=True, exist_ok=True)
+
+# CFD simulation parameters and reaction rate constant
+Vs = 1
+tau = 10
+Q = Vs/tau
+k = 0.1
+
+# Setup analytical solutions
+a_bc = 1 # BC
+a_ic = 0 # IC
+Ca_func = lambda V, t: ( a_ic * np.exp(-k*t) * (1- HV(t-V/Q, 1)) ) + ( a_bc * np.exp(-k*V/Q) * HV(t-V/Q, 1) )
+						
+b_bc = 0 # BC
+b_ic = 0 # IC
+Cb_func = lambda V, t: 2*a_ic * ( 1 - HV(t-V/Q, 1) ) * (1-np.exp(-k*t))  + 2*a_bc*HV(t-V/Q, 1) * (1-np.exp(-k*V/Q)) + (b_bc - b_ic)*HV(t-V/Q, 1) + b_ic
+
+# Solve for different volume discretization points in PFR
+for pointsPFR in [21, 101, 501]:
+	
+	# Runtime change of points_per_pfr parameter regardless of what configuration file was given.
+	os.chdir(Path(__file__).parents[0])
+	config_parser = ConfigParser('CONFIG')
+	config_parser['SIMULATION']['points_per_pfr'] = str(pointsPFR)
+	run(config_parser)
+
+	# get openccm results for c and t vectors
+	outputs = os.listdir(os.getcwd()+'/output_ccm')
+	t_vec = np.load(os.getcwd()+'/output_ccm/pfr_t.npy')
+	c_vec = np.load(os.getcwd()+'/output_ccm/pfr_concentrations.npy')
+
+	# get V arrays for function calls
+	V_inlet = np.zeros((len(t_vec), ))
+	V_mid = np.zeros((len(t_vec), )) + 0.5
+	V_outlet = np.ones((len(t_vec), ))
+
+	# organize analytical results, use same time domain points as openccm for error calculation purposes
+	Ca_inlet_an		= Ca_func(V_inlet,  t_vec)
+	Ca_mid_an		= Ca_func(V_mid,    t_vec)
+	Ca_outlet_an 	= Ca_func(V_outlet, t_vec)
+	Cb_inlet_an 	= Cb_func(V_inlet,  t_vec)
+	Cb_mid_an 		= Cb_func(V_mid,    t_vec)
+	Cb_outlet_an 	= Cb_func(V_outlet, t_vec)
+
+	# organize openccm results, use same time domain points as openccm for error calculation purposes
+	mid = c_vec.shape[1] // 2
+
+	Ca_inlet_num	= c_vec[0,   0, :]
+	Ca_mid_num		= c_vec[0, mid, :]
+	Ca_outlet_num	= c_vec[0,  -1, :]
+	Cb_inlet_num	= c_vec[1,   0, :]
+	Cb_mid_num		= c_vec[1, mid, :]
+	Cb_outlet_num	= c_vec[1,  -1, :]
+
+	# group all results to simplify plotting code
+	inlet = [(Ca_inlet_an, Ca_inlet_num), (Cb_inlet_an, Cb_inlet_num)]
+	mid = [(Ca_mid_an, Ca_mid_num), (Cb_mid_an, Cb_mid_num)]
+	outlet = [(Ca_outlet_an, Ca_outlet_num), (Cb_outlet_an, Cb_outlet_num)]
+	plotlist = [inlet, mid, outlet]
+	plotnames = ['inlet', 'midpoint', 'outlet']
+
+	# error computing function
+	def err_func(an, num, i_0):
+		return np.sum(np.abs(an[i_0:] - num[i_0:])) / len(t_vec[i_0:])
+
+	# Enforce bounds for plot so that it's consistent for all figures
+	y_lim = [-0.05, 2.05]
+
+	# plot results
+	for i, toplot in enumerate(plotlist):
+		plt.figure()
+
+		# Because the sampling is heavily skewed towards the beginning, we don't want to sample them all since it will skew our results
+		i_start = min(
+			np.argmax(abs(toplot[0][1]) > 1e-10),
+			np.argmax(abs(toplot[1][1]) > 1e-10))
+
+		# get error calculation results
+		errA_value = err_func(toplot[0][0], toplot[0][1], i_start)
+		errA = (f"err [A]_{plotnames[i]}" + " = {:0.3e}").format(errA_value)
+
+		errB_value = err_func(toplot[1][0], toplot[1][1], i_start)
+		errB = (f"err [B]_{plotnames[i]}" + " = {:0.3e}").format(errB_value)
+
+		# Plot all results
+		plt.text(0, 1.1, '\n'.join((errA, errB)))
+		plt.plot(t_vec, toplot[0][0], color='r', label='[A] analytical')
+		plt.scatter(t_vec, toplot[0][1], s=8, color='r', label='[A] openccm')
+
+		plt.plot(t_vec, toplot[1][0], color='b', label='[B] analytical')
+		plt.scatter(t_vec, toplot[1][1], s=8, color='b', label='[B] openccm')
+
+		plt.xlabel('Time [s]')
+		plt.ylabel('Concentration [M]')
+		plt.title(f"{pointsPFR} DoF PFR with Rxn: A -> 2B, @ V = {plotnames[i].capitalize()}")
+		plt.ylim(y_lim)
+		plt.legend(loc='upper left')
+
+		plt.savefig(f"analysis/{plotnames[i]}_{pointsPFR}_points.png")
+		#plt.show()
+		plt.close()
+
+	print('Inlet, midpoint, and outlet concentration plots saved.')
+
+	# Visualize the concentration in the reactor as a function of time
+	plt.figure()
+	fig, ax = plt.subplots()
+	plt.xlabel("Volume Along Reactor [V]")
+	plt.ylabel("Concentration [M]")
+	plt.title(f"PFR with Rxn: A -> 2B, @ t={t_vec[0]:.4f}")
+	V = Vs/(c_vec.shape[1]-1) * np.array([i for i in range(c_vec.shape[1])], dtype=float)
+	a_analytic, = ax.plot(V, Ca_func(V, t_vec[0]), 'r')
+	a_openccm,  = ax.plot(V, c_vec[0, :, 0], 'ro')
+	b_analytic, = ax.plot(V, Cb_func(V, t_vec[0]), 'b')
+	b_openccm,  = ax.plot(V, c_vec[1, :, 0], 'bo')
+	plt.legend(['[A] analytic', '[A] openccm', '[B] analytic', '[B] openccm'], loc='best')
+	plt.ylim(y_lim)
+
+	if save_movie:
+		def animate(i_t):
+			a_analytic.set_ydata(Ca_func(V, t_vec[i_t]))
+			a_openccm. set_ydata(c_vec[0, :, i_t])
+			b_analytic.set_ydata(Cb_func(V, t_vec[i_t]))
+			b_openccm. set_ydata(c_vec[1, :, i_t])
+			plt.title(f"PFR with Rxn: A -> 2B, @ t={t_vec[i_t]:.4f}")
+
+		try:
+			writer = animation.writers['ffmpeg'](fps=30, bitrate=1800, codec='libx264')
+			ext = 'mp4'
+			print('Using ffmpeg writer for animation.')
+		except RuntimeError: # if ffmpeg not found locally, use PillowWriter
+			print('ffmpeg not found. Resorting to Pillow writer...')
+			writer = animation.PillowWriter(fps=30, bitrate=1800, codec='libx264')
+			ext = 'gif'
+
+		ani = animation.FuncAnimation(fig, animate, frames=range(len(t_vec)))
+		ani.save(f"analysis/transient_{pointsPFR}_points.{ext}", writer, dpi=300)
+
+		plt.close()
+		print(f'Transient animation saved as transient_{pointsPFR}_points.{ext} in analysis/.')
+	else:
+		print('Transient movie simulation not created as directed by pfr_analysis.py.')

--- a/examples/simple_reactors/pfr/reactions
+++ b/examples/simple_reactors/pfr/reactions
@@ -1,0 +1,5 @@
+[REACTIONS]
+R1: a -> 2b
+
+[RATES]
+R1: 0.1


### PR DESCRIPTION
Added code, documentation, and configuration files for various simple reactor (cstr/pfr) examples, such as
* cstr - reversible linear reaction
* cstr - two irreversible linear reactions
* pfr - irreversible linear reaction

These examples outline the analytical solution to simple mass balance systems which are used to validate OpenCCM's numerical implementation.