### PR TITLE
Fix floating point issue in tweak_compartment_flows

### DIFF
--- a/pytests/CONFIG
+++ b/pytests/CONFIG
@@ -1,0 +1,33 @@
+[INPUT]
+opencmp_config_file_path    = config_INS
+opencmp_sol_file_path       = output/ins_sol/ins_0.0.sol
+num_refinements             = 1
+min_magnitude_threshold     = 6e-5
+
+no_flux_names       = ("wall",)
+ignored_names       = None
+domain_inlet_names  = ("inlet",)
+domain_outlet_names = ("outlet",)
+
+[COMPARTMENTALIZATION]
+bc_names_for_seeds  = ("inlet",)
+min_compartment_size = 0.05
+
+[COMPARTMENT MODELLING]
+model = PFR
+
+[SIMULATION]
+run                 = True
+t_span              = 0, 500
+points_per_pfr      = 2
+specie_names        = a
+initial_conditions  = a -> 0
+boundary_conditions = a: inlet -> 1
+
+[POST-PROCESSING]
+inlet_bc_name          = inlet
+outlet_bc_name         = outlet
+output_VTK             = False
+plot_results           = True
+calculate_rtd          = True
+network_diagram        = False

--- a/pytests/test_tweak_compartment_flows.py
+++ b/pytests/test_tweak_compartment_flows.py
@@ -1,0 +1,66 @@
+import numpy as np
+
+from typing import Dict
+
+from openccm import ConfigParser
+from openccm.mesh import GroupedBCs
+from openccm.compartment_models.helpers import tweak_compartment_flows, tweak_final_flows
+
+
+def test_tweak_compartment_flows():
+    grouped_bcs = GroupedBCs(ConfigParser('CONFIG'))
+
+    m = 100              # Number of compartments on each side of the centerline
+    n = 1 + 2*m         # Total number of compartments
+    delta_x = 1. / n    # Size of each compartment's edge
+
+    V_max        = 1e-6
+    frac_side    = 1e-5
+    noise_factor = 1e-4
+
+    np.random.seed(0)
+
+    def velocity(xl, xr):
+        """0th order projection of a parabolic flow profile in a pipe with walls at x=0 and x=1"""
+        return 4*V_max / (2 * (xr - xl)) * ((xr ** 2 - xl ** 2) - 2 / 3 * (xr ** 3 - xl ** 3))
+
+    connection_pairings: Dict[int, Dict[int, int]] = {i: {} for i in range(n)}
+    volumetric_flows = {}
+    # Add inlet and outlet connections
+    for i, connections_i in connection_pairings.items():
+        volumetric_flows[i+1]   = (1 + noise_factor * np.random.rand()) * delta_x * velocity(delta_x*i, delta_x*(i+1))
+        volumetric_flows[n+i+1] = (1 + noise_factor * np.random.rand()) * delta_x * velocity(delta_x*i, delta_x*(i+1))
+        connections_i[(i+1)]    = grouped_bcs.id('inlet')   # Inlet BC
+        connections_i[-(n+i+1)] = grouped_bcs.id('outlet')  # Outlet BC
+
+    # Bad inter-compartment connections from i to i+1
+    for i in range(0, n//2):
+        j = 2*n + (i+1)
+        volumetric_flows[j] = V_max * frac_side * np.random.rand()
+        connection_pairings[i][-j] = i+1    # Outlet for i
+        connection_pairings[i+1][j] = i     # Inlet for i+1
+
+    # Add bad inter-compartment connections from i to i-1
+    for i in range(n//2+1, n):
+        j = 2 * n + i
+        volumetric_flows[j] = V_max * frac_side * np.random.rand()
+        connection_pairings[i-1][j] = i     # Inlet for i-1
+        connection_pairings[i][-j] = i-1    # Outlet for i
+
+    # Calculate CoM before optimization (positive means net-inflow)
+    def calculate_com(volumetric_flows, connection_pairings):
+        def sign(x): return 1 if x > 0 else -1
+
+        overall_com = sum(volumetric_flows[i+1] for i in range(n)) - sum(volumetric_flows[i+1] for i in range(n, 2*n))
+        compartment_com = {}
+        for id_compartment, connections in connection_pairings.items():
+            compartment_com[id_compartment] = sum(sign(id_connection) * volumetric_flows[abs(id_connection)] for id_connection in connections)
+        return overall_com, compartment_com
+
+    # tweak_compartment_flows modifies in place, make a copy to see before and after
+    volumetric_flows_orig = volumetric_flows.copy()
+    overall_com_before, compartment_com_before = calculate_com(volumetric_flows_orig, connection_pairings)
+    tweak_compartment_flows(connection_pairings, volumetric_flows, grouped_bcs, atol_opt=1e-2, rtol_opt=0.0)
+    overall_com_after,  compartment_com_after  = calculate_com(volumetric_flows, connection_pairings)
+
+


### PR DESCRIPTION
Current implementation performs the flow optimization on the original flowrate values. This can lead to numerical issues if there exist flowrates which are very small (order of 1e-6) which were not removed earlier in the process (e.g. if the user-set tolerance was 1e-7). The optimization routine struggled to properly account for them, resulting scenarios where net-outflow remained.

This PR scales all flows by on the smallest flowrate for the purposes of optimization, and then rescales them back to their original ranges. The checks for conservation of mass are performed after this scaling to ensure that the final values satisfy the no net-outflow condition.