### PR TITLE
Fixed bug in applying initial value of boundary conditions for PFRs

### DIFF
--- a/openccm/system_solvers/boundary_and_initial_conditions.py
+++ b/openccm/system_solvers/boundary_and_initial_conditions.py
@@ -138,7 +138,7 @@ def create_boundary_conditions(c0:                  np.array,
     if need_time_deriv_version:
         for bc_id, species_dict in bc_dict_for_c0.items():
             for specie, bc_eqn in species_dict.items():
-                c0[specie_names.index(specie), points_for_bc[bc_id]] += np.array(Q_weights[bc_id]) * float(bc_eqn.evalf(subs={'t': t0}))
+                np.add.at(c0[specie_names.index(specie)], points_for_bc[bc_id], Q_weights[bc_id]) * float(bc_eqn.evalf(subs={'t': t0}))
 
     bcs_names_used = sorted(bcs_names_used)  # Convert to list to keep order consistent
 


### PR DESCRIPTION
A PFR may have multiple connections to the same BC. The current way that the augment assignment was written does not correctly handle this case (See the code snippet below for how it currently, incorrectly, operates). This PR changes this assignment to correctly handle multiple connections to the same BC.

```Python
c   = np.zeros(5)
idx = np.array([1,   2,   3,   4,   4,    4,    4])
bs  = np.array([1.0, 1.0, 1.0, 0.8, 0.01, 0.05, 0.14])

c[idx] += b
# Expected [0.0, 1.0, 1.0, 1.0, 1.0]
# Actual   [0.0, 1.0, 1.0, 1.0, 0.14]
```
This will leave `c[4]` with a value of `0.14` rather than the value of  `1.0` as expected.

