### PR TITLE
Support for alphanumeric species and improved readability in reactions.py

### DIFF
--- a/openccm/system_solvers/reactions.py
+++ b/openccm/system_solvers/reactions.py
@@ -181,8 +181,8 @@ def parse_reactions(specie_order: List[str], rxn_book: Dict[str, List[str]]) -> 
     Notes:
         The reaction parser only supports forward (written) reactions (i.e. use of ->). Reversible reactions must be written as two independent reactions with their associated rate constants.
         The reactions parser can parse the general reaction: aA1 + bB2 + [...] -> gG7 + hH8 + [...].
-        All chemical species can be alphanumeric with underscores (if desired), but cannot contain +/- symbols (i.e. for ions). 
-        We recommend using "m" or "p" for + and - ions, respectively.
+        All chemical species can be alphanumeric with underscores (if desired), but cannot contain +/- symbols (i.e. for ions) in the specie name. 
+        We recommend using "_m" or "_p" for + and - ions, respectively. I.e.: Na+ should be written as Na_p in the reactions and main configuration file.
 
         An appropriate reactions configuration file for the reversible reaction N2O4 <-> 2NO2 with k_f = 1e-2 and k_r = 3e-4 (these are hypothetical rates) would be:
 


### PR DESCRIPTION
Two major changes to reactions are introduced:

1. Alphanumeric chemical species with certain special characters (i.e. '_' allowed, but '+' and '-' not allowed) are now supported by the reactions configuration parser. While previously only alphabetic specie names were allowed (i.e. a, ab, bc), an expanded range of specie names is newly supported (i.e. Na2SO4 or Na_2SO_4). 
2. The main parser function parse_reactions() has been split into 2 functions to improve readability. A new function was created, organize_reactions_input(), which digests the initial reactions file and groups together reactions and the associated rates, while also employing many checks to ensure the user provided an acceptable reactions config. 