### PR TITLE
Fix for incorrect variable passed to linprog

### DIFF
--- a/pytests/test_run_examples.py
+++ b/pytests/test_run_examples.py
@@ -1,0 +1,48 @@
+
+from pathlib import Path
+import shutil
+from openccm import run, ConfigParser
+
+rel_path_to_examples = '../examples/'
+
+
+def clean_previous_results(configparser: ConfigParser) -> None:
+    def delete_and_recreate_folder(path: str) -> None:
+        if Path(path).exists():
+            shutil.rmtree(path)
+            Path(path).mkdir(parents=True)
+
+    if configparser.need_to_update_paths:
+        configparser.update_paths()
+
+    delete_and_recreate_folder(configparser['SETUP']['tmp_folder_path'])
+    delete_and_recreate_folder(configparser['SETUP']['log_folder_path'])
+    delete_and_recreate_folder(configparser['SETUP']['output_folder_path'])
+
+
+def clean_and_run(working_directory: str) -> None:
+    configparser = ConfigParser(working_directory + 'CONFIG')
+    configparser['SETUP']['working_directory'] = working_directory
+
+    clean_previous_results(configparser)
+    run(configparser)
+
+
+def test_opencmp_cstr_reversible():
+    clean_and_run(rel_path_to_examples + 'simple_reactors/cstr/reversible/')
+
+
+def test_opencmp_cstr_irreversible():
+    clean_and_run(rel_path_to_examples + 'simple_reactors/cstr/irreversible/')
+
+
+def test_opencmp_pfr():
+    clean_and_run(rel_path_to_examples + 'simple_reactors/pfr/')
+
+
+def test_opencmp_recirc():
+    clean_and_run(rel_path_to_examples + 'OpenCMP/pipe_with_recirc_2d/')
+
+
+def test_openfoam_2d_pipe():
+    clean_and_run(rel_path_to_examples + 'OpenFOAM/pipe_with_recirc/')


### PR DESCRIPTION
`linprog` takes a parameter [integrality](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.linprog.html) which specifies whether the result should be continuous, semi-continuous, or an integer. I previous incorrectly set this value to `1` which forced the results to be integers. I have changed it to the correct value of `2` which requires the results to be continuous but bounded by the specified bounds.

Also, I have included a pytest file which runs all of the examples. It makes no comparison of the results, it's purpose is to make sure that all of the examples pass their assert statements.