### PR TITLE
Added ability to specify time points at which to sample simulation

### DIFF
--- a/CONFIG
+++ b/CONFIG
@@ -66,6 +66,8 @@ atol_opt                = [1e-2]
 run                 = [True]
 # Time range for simulation.
 t_span              = 0, 100
+# The time points at which to obtain compartmental model simulation results. Options are: (all), (delta_t, linear), (log, num_points), and (t1, t2, t3, ... , t4)
+t_eval              = [all]
 # Initial time-step, needed since the solver has issues with time-varying BCs otherwise.
 first_timestep      = [0.0001]
 # If using PFRs this the number of discretization points per PFR (must be at least 2).

--- a/openccm/config_functions/expanded_config_parser.py
+++ b/openccm/config_functions/expanded_config_parser.py
@@ -48,6 +48,7 @@ config_defaults: Dict = {
                    'reactions_file_path': 'None',
                    'rtol': 1e-6,
                    'atol': 1e-6,
+                   't_eval': 'all',
                    'boundary_conditions': ''},
     'POST-PROCESSING': {'save_to_file': True,
                         'plot_results': False,

--- a/openccm/system_solvers/boundary_and_initial_conditions.py
+++ b/openccm/system_solvers/boundary_and_initial_conditions.py
@@ -24,7 +24,7 @@ import sympy as sp
 from sympy.abc import x, y, z, t
 
 from ..mesh import GroupedBCs
-from .math_functions import H
+from .helper_functions import H
 
 BC_TEMPLATE = "@njit(inline='always', cache=True)\n" + \
               "def {}(t):\n" + \

--- a/openccm/system_solvers/cstr_system.py
+++ b/openccm/system_solvers/cstr_system.py
@@ -23,6 +23,7 @@ import numpy as np
 from numba import njit
 from scipy.integrate import solve_ivp
 
+from .helper_functions import generate_t_eval
 from ..config_functions import ConfigParser
 from ..mesh import GroupedBCs
 
@@ -80,6 +81,8 @@ def solve_system(
 
     assert first_timestep > 0
 
+    t_eval = generate_t_eval(config_parser)
+
     if os.path.exists('reaction_code_gen.py'):
         os.remove('reaction_code_gen.py')
 
@@ -131,7 +134,7 @@ def solve_system(
 
     args = (Q_div_v, c_shape, reactions, bcs)
 
-    output = solve_ivp(ddt, t_span, c0, method=solver, atol=atol, rtol=rtol, args=args, first_step=first_timestep)
+    output = solve_ivp(ddt, t_span, c0, method=solver, atol=atol, rtol=rtol, args=args, first_step=first_timestep, t_eval=t_eval)
     t: np.ndarray = output.t
     c: np.ndarray = output.y
     c = c.reshape(c_shape + t.shape)  # (num_species, num_points, num_timesteps)

--- a/openccm/system_solvers/helper_functions.py
+++ b/openccm/system_solvers/helper_functions.py
@@ -14,8 +14,13 @@
 # You should have received a copy of the GNU Lesser General Public License along with OpenCCM. If not, see             #
 # <https://www.gnu.org/licenses/>.                                                                                     #
 ########################################################################################################################
+from typing import Optional, Iterable
+
+import numpy as np
 from numpy import pi
 from sympy import Function, Piecewise, cos
+
+from openccm import ConfigParser
 
 
 class H(Function):
@@ -43,3 +48,57 @@ class H(Function):
             ((y_start+y_stop)/2 + (y_start-y_stop)/2 * cos((t-t_start)*pi/dt),  True)
         )
 
+
+def generate_t_eval(config_parser: ConfigParser) -> Optional[Iterable]:
+    """
+    Helper function to generate the time evaluation points which are given to solve_ivp.
+
+    4 options are available:
+        1. 'all':               DEFAULT. All time steps will be returned.
+        2. dt, 'linear':        Linear distribution of points between t0 and tf with a spacing of dt.
+                                t0 and tf are guaranteed to be the last and end point, even if the last step
+                                is not of size dt.
+        3. 'log', num_points:   Logarithmic distribution of points between t0 and tf with num_points points.
+                                The exact values of t0 and tf are guaranteed to be the first and last point.
+                                If t0 is 0, this is range is approximated by having a log distribution between
+                                first_timestep and tf with num_points-1 points and then pre-pending 0 to the list.
+        4. 't1, t2, ..., tn':   Arbitrary time points which are sorted. Only requirements are: t1 >= t0 and tn <= tf.
+
+    Args:
+        config_parser: The OpenCCM ConfigParser from which to get the t_eval string and the start and end times.
+
+    Returns:
+        ~:  Type depends on t_eval form. None is returned if all data points are to be stored,
+            otherwise a list of floats or a numpy array is returned.
+    """
+    t_evel_str = config_parser.get_list(['SIMULATION', 't_eval'], str)
+    t0, tf     = config_parser.get_list(['SIMULATION', 't_span'], float)
+    assert t0 >= 0
+
+    if len(t_evel_str) == 1 and t_evel_str[0].lower() == 'all':
+        return None
+    elif len(t_evel_str) == 2 and 'linear' in t_evel_str[1].lower():
+        dt = float(t_evel_str[0])
+
+        ts = []
+        t = t0
+        while t < tf:
+            ts.append(t)
+            t += dt
+        ts.append(tf)
+    elif len(t_evel_str) == 2 and 'log' in t_evel_str[0].lower():
+        num_samples = int(t_evel_str[1])
+        first_timestep = config_parser.get_item(['SIMULATION', 'first_timestep'], float)
+        if t0 == 0:
+            ts = np.zeros(num_samples)
+            ts[1:] = np.logspace(np.log10(first_timestep), np.log10(tf), num_samples-1)
+        else:
+            ts = np.logspace(np.log10(t0), np.log10(tf), num_samples)
+        ts[0]  = t0  # Get around any rounding errors that occurred when doing 10^log10(t0).
+        ts[-1] = tf  # Get around any rounding errors that occurred when doing 10^log10(tf).
+    else:  # literal string of numbers
+        ts = sorted(float(time) for time in t_evel_str)
+        if ts[0] < t0 or ts[-1] > tf:
+            raise ValueError('Invalid time range provided, times must be within range specified by t_range.')
+
+    return ts

--- a/openccm/system_solvers/pfr_system.py
+++ b/openccm/system_solvers/pfr_system.py
@@ -22,6 +22,7 @@ import numpy as np
 from scipy.integrate import solve_ivp
 from numba import njit
 
+from .helper_functions import generate_t_eval
 from ..config_functions import ConfigParser
 from ..mesh import GroupedBCs
 
@@ -83,6 +84,8 @@ def solve_system(
 
     assert first_timestep > 0
     assert points_per_pfr >= 2
+
+    t_eval = generate_t_eval(config_parser)
 
     connections, volumes, Q_connections, _ = pfr_network
 
@@ -174,7 +177,7 @@ def solve_system(
                                                         t0=t_span[0])
 
     args = (Q_weight, _ddt0, connected_to_another_inlet, all_inlet_ids, c_shape, reactions, bcs)
-    output = solve_ivp(ddt, t_span, c0, method=solver, atol=atol, rtol=rtol, args=args, first_step=first_timestep)
+    output = solve_ivp(ddt, t_span, c0, method=solver, atol=atol, rtol=rtol, args=args, first_step=first_timestep, t_eval=t_eval)
 
     ts: np.ndarray = output.t
     c:  np.ndarray = output.y


### PR DESCRIPTION
Previously every timestep that solve_ivp took was returned in the result. These may not be uniformly sampled, and may be far more than the user wants. That was left as the default behaviour, but additional options were added:
1. All points.
2. Linearly spaced points between t_0 and t_final with delta_t spacing inbetween them.
3. Logarithmic spacing with num_points total sampling points.
4. Explicitly providing a list of time points, i.e. (t1, t2, ..., tn).