### PR TITLE
Speed Up Compartmentalization and Immutable CMesh

### DIFF
--- a/openccm/compartmentalize/unidirectional.py
+++ b/openccm/compartmentalize/unidirectional.py
@@ -738,7 +738,7 @@ def _calculate_compartments(elements_not_in_a_compartment:  Set[int],
     """
     Wrapped function to allow for numba usage.
 
-    Iterating one element at a time, group neighsabouring elements into compartments.
+    Iterating one element at a time, group neighbouring elements into compartments.
     The algorith works as follows:
         1. (Arbitrarily) pick a seed element from the list of seed elements
             - This list is original the list of all elements which share a facet with certain user-specified boundaries
@@ -940,8 +940,7 @@ def _remove_unwanted_elements(mesh: CMesh, dir_vec: np.ndarray) -> Tuple[Set[int
 
     # Remove all of these elements from the mesh connectivity
     for element in removed_elements:
-        for element_neighbour in mesh.element_connectivity.pop(element):
-            mesh.element_connectivity[element_neighbour].remove(element)
+        for element_neighbour in mesh.element_connectivity[element]:
             if element_neighbour not in removed_elements:
                 elements_with_neighbour_removed.add(element_neighbour)
 
@@ -966,9 +965,8 @@ def _remove_unwanted_elements(mesh: CMesh, dir_vec: np.ndarray) -> Tuple[Set[int
         # If the element is connected to only one other element/flux-BC we have to remove it.
         if num_neighbours + num_bcs <= 1:
             removed_elements.add(element)
-            for element_neighbour in mesh.element_connectivity.pop(element):
+            for element_neighbour in mesh.element_connectivity[element]:
                 elements_with_neighbour_removed.add(element_neighbour)
-                mesh.element_connectivity[element_neighbour].remove(element)
 
     # Create a set of all elements and remove the removed elements from it
     valid_elements = set(i for i in range(dir_vec.shape[0]))

--- a/openccm/mesh/cmesh.py
+++ b/openccm/mesh/cmesh.py
@@ -88,7 +88,7 @@ class CMesh:
                  facet_connectivity: Tuple[Tuple[int, ...], ...],
                  element_facets: Tuple[Tuple[int, ...], ...],
                  element_vertices: Tuple[Tuple[int, ...], ...],
-                 element_connectivity: Dict[int, List[int]],
+                 element_connectivity: Tuple[Tuple[int, ...], ...],
                  element_sizes: np.ndarray,
                  grouped_bcs: GroupedBCs,
                  facet_to_bc_map: np.ndarray,

--- a/openccm/mesh/convert_ngsolve.py
+++ b/openccm/mesh/convert_ngsolve.py
@@ -127,12 +127,12 @@ def _create_bc_mappings(mesh: 'ngsolve.Mesh', grouped_bcs: GroupedBCs) -> Tuple[
     return facet_to_bc_id_map, bc_name_to_facet_map
 
 
-def _create_element_connectivity(mesh: 'ngsolve.Mesh', all_elements: Tuple['ngsolve.comp.Ngs_Element']) -> Dict[int, List[int]]:
+def _create_element_connectivity(mesh: 'ngsolve.Mesh', all_elements: Tuple['ngsolve.comp.Ngs_Element']) -> Tuple[Tuple[int, ...], ...]:
     """
     Returns:
         neighbours_all: A tuple of the IDs of all neighbouring elements of a given element ID, indexed by that ID.
     """
-    neighbours_all: Dict[int, List[int]] = dict()
+    neighbours_all: List[Tuple[int], ...] = []
 
     for element in all_elements:
         # Using a set, rather than a list, to make handling of duplicates trivial
@@ -145,9 +145,9 @@ def _create_element_connectivity(mesh: 'ngsolve.Mesh', all_elements: Tuple['ngso
         # Make sure that an element isn't listed as its own neighbour
         neighbours_of_element.remove(element.nr)
 
-        neighbours_all[element.nr] = sorted(neighbours_of_element)
+        neighbours_all.append(tuple(sorted(neighbours_of_element)))
 
-    return neighbours_all
+    return tuple(neighbours_all)
 
 
 def _create_facet_connectivity(mesh: 'ngsolve.Mesh') -> Tuple[Tuple[int, ...], ...]:

--- a/openccm/mesh/convert_openfoam.py
+++ b/openccm/mesh/convert_openfoam.py
@@ -163,7 +163,7 @@ def _get_facet_element_info(owner: np.ndarray, neighbour: np.ndarray) -> Tuple[
     return tuple(facet_elements), element_facets_tuple
 
 
-def _create_element_connectivity(neighbour: np.ndarray, owner: np.ndarray) -> Dict[int, List[int]]:
+def _create_element_connectivity(neighbour: np.ndarray, owner: np.ndarray) -> Tuple[Tuple[int, ...], ...]:
     """
     Create element connectivity.
 
@@ -182,8 +182,8 @@ def _create_element_connectivity(neighbour: np.ndarray, owner: np.ndarray) -> Di
     for i in range(len(neighbour)):
         element_connectivity[    owner[i]].add(neighbour[i])
         element_connectivity[neighbour[i]].add(owner[i])
-        
-    return {element: sorted(neighbours) for element, neighbours in element_connectivity.items()}
+
+    return tuple(tuple(sorted(element_connectivity[element])) for element in sorted(element_connectivity.keys()))
 
 
 def _get_element_vertices(element_facets: Tuple[Tuple[int, ...], ...], facet_vertices: Tuple[Tuple[int, ...], ...]) -> Tuple[Tuple[int, ...], ...]:


### PR DESCRIPTION
This PR does two related things:
1. It uses the `elements_not_in_a_compartment` set inside `_calculate_compartments` to avoid having to change the element connectivity inside the CMesh object, allowing it to be immutable and less error prone.
2. It Further speeds up `_calculate_compartments` by changing `seeds` from being a List (poorly chosen on my part) to the keys in an OrderedDict.

Some more explanation on point 2. The seed elements are initially specified by the user, but the collection gets expanded upon by the `_calculate_compartments` as each compartment is grown. It involved tens of thousands of evaluations of `if x not in seeds` on large meshes, which is O(N) in time where N is the number of seed elements. N can easily get into the tens of thousands.

A replacement to List needed: 1) constant time lookup, 2) maintain insertion order, and 3) a way to pop items from the front of the insertion order. Alternative options could have been Set, Dict, or Deque but none had all three.

Instead the keys of an OrderedDict are used, which satisfies all 3 criteria. The value used for each key is `None` in order to keep the total size to a minimum.