### PR TITLE
Fix to merging of compartments when using CSTRs

### DIFF
--- a/openccm/compartment_models/__init__.py
+++ b/openccm/compartment_models/__init__.py
@@ -18,8 +18,8 @@ from typing import Dict, Tuple, List, Set
 
 import numpy as np
 
-from .cstr import create_cstr_network
-from .pfr import create_pfr_network
+from .cstr import create_cstr_network, connect_cstr_compartments
+from .pfr import create_pfr_network, connect_pfr_compartments
 from ..config_functions import ConfigParser
 from ..mesh import CMesh
 

--- a/openccm/compartment_models/cstr.py
+++ b/openccm/compartment_models/cstr.py
@@ -23,10 +23,10 @@ from ..config_functions import ConfigParser
 from ..mesh import CMesh, GroupedBCs
 
 
-def _connect_cstr_compartments(compartment_network: Dict[int, Dict[int, Dict[int, Tuple[int, np.ndarray]]]],
-                               mesh: CMesh,
-                               v_vec: np.ndarray,
-                               config_parser: ConfigParser) \
+def connect_cstr_compartments(compartment_network: Dict[int, Dict[int, Dict[int, Tuple[int, np.ndarray]]]],
+                              mesh: CMesh,
+                              v_vec: np.ndarray,
+                              config_parser: ConfigParser) \
         -> Tuple[Dict[int, Dict[int, int]],
                  Dict[int, float]]:
     """
@@ -49,7 +49,6 @@ def _connect_cstr_compartments(compartment_network: Dict[int, Dict[int, Dict[int
         config_parser:          The OpenCCM ConfigParser.
 
     Returns:
-        id_next_connection:     The integer to use for the next connection ID
         connection_pairing:     Dictionary storing info about which other compartments a given compartment is connected to
                                 - Key is compartment ID
                                 - Values is a Dict[int, int]
@@ -166,7 +165,7 @@ def create_cstr_network(compartments:           Dict[int, Set[int]],
     ####################################################################################################################
     # 1. Create connections between compartments
     ####################################################################################################################
-    connection_pairing, _volumetric_flows = _connect_cstr_compartments(compartment_network, mesh, vel_vec, config_parser)
+    connection_pairing, _volumetric_flows = connect_cstr_compartments(compartment_network, mesh, vel_vec, config_parser)
 
     ####################################################################################################################
     # 2. Calculate volume of each compartment

--- a/openccm/compartment_models/pfr.py
+++ b/openccm/compartment_models/pfr.py
@@ -21,7 +21,6 @@ from typing import Dict, List, Set, Tuple
 
 import numpy as np
 
-from ..compartmentalize import connect_compartments_using_unidirectional_assumptions
 from ..config_functions import ConfigParser
 from ..mesh import CMesh, GroupedBCs
 from .helpers import tweak_compartment_flows, tweak_final_flows
@@ -93,7 +92,7 @@ def create_pfr_network(compartments:        Dict[int, Set[int]],
     # 1. Create connections between compartments
     ####################################################################################################################
     # 1.1 Initial connections
-    results_1 = connect_compartments_using_unidirectional_assumptions(compartment_network, compartments, mesh, dir_vec, vel_vec, True, config_parser)
+    results_1 = connect_pfr_compartments(compartment_network, compartments, mesh, dir_vec, vel_vec, True, config_parser)
     id_next_connection, connection_distances, connection_pairing, compartment_network, compartments, _volumetric_flows = results_1
 
     # 1.2 Optimize connections to prevent flow reversal when creating the intra-compartment flows.
@@ -871,3 +870,291 @@ def _fix_domain_boundary_connection_ordering(inlets_and_outlets: List[Tuple[floa
                 raise AssertionError(f"Domain inlet/outlets for compartment {id_compartment} were not ordered properly")
 
     return inlets_and_outlets
+
+
+def connect_pfr_compartments(compartment_network:  Dict[int, Dict[int, Dict[int, Tuple[int, np.ndarray]]]],
+                             compartments:         Dict[int, Set[int]],
+                             mesh:                 CMesh,
+                             dir_vec:              np.ndarray,
+                             vel_vec:              np.ndarray,
+                             final:                bool,
+                             config_parser:        ConfigParser) \
+        -> Tuple[int,
+                 Dict[int, Dict[int, float]],
+                 Dict[int, Dict[int, int]],
+                 Dict[int, Dict[int, Dict[int, Tuple[int, np.ndarray]]]],
+                 Dict[int, Set[int]],
+                 Dict[int, float]]:
+    """
+    Function to take a compartment network and compartments and create the connections between them.
+    Calculates the flowrates and direction of flow between connected compartments.
+    CAN RETURN MULTIPLE CONNECTIONS BETWEEN TWO COMPARTMENTS.
+
+    A surface shared by two compartments is made up of facets, all facets below the specified threshold
+    (flow_threshold_i) are removed from the surface.
+    Then the surface is split into contiguous subsurfaces which all have the same direction of flow.
+    Each subsurface is treated as a separate connection between the two compartments that it's between.
+
+    Args:
+        compartment_network:    A dictionary representation of the compartments in the network.
+                                Keys are compartment IDs, and whose values are dictionary.
+                                    For each of those dictionaries, the keys are the index of a neighboring compartment
+                                    and the values are another dictionary.
+                                        For each of those dictionaries, the keys are the index of the bounding facet
+                                        between the two compartments, and the values Tuples.
+                                            - The first entry in the tuple is the index of the element
+                                              on the boundary inside the compartment.
+                                            - The second entry in the tuple is a numpy array representing
+                                              the unit normal for that boundary facing out of the compartment.
+        compartments:           A dictionary representation of the elements in the compartments.
+                                Keys are compartment IDs, values are sets containing the indices
+                                of the elements in the compartment.
+        mesh:                   The mesh the problem was solved on.
+        dir_vec:                Numpy array of direction vectors, row i is for element i.
+        vel_vec:                Numpy array of velocity vectors, row i is for element i.
+        final:                  If asserts and all calculations should be performed.
+                                This is set to True when function is called from merge_compartments since some may
+                                be too small for the invariants to be true.
+        config_parser:          The OpenCCM ConfigParser
+
+    Returns:
+        Tuple of two values:
+            id_next_connection:     The integer to use for the next connection ID.
+            connection_distances:   Dictionary storing the distance.
+            connection_pairing:     Dictionary storing info about which other compartments a given compartment is connected to.
+                                        - First key is compartment ID
+                                        - Values is a Dict[int, int]
+                                            - Key is connection ID (positive inlet into this compartment, negative is outlet)
+                                            - Value is the ID of the compartment on the other side
+            compartment_network:    The compartment network passed in.
+            compartments            The compartments passed in.
+            volumetric_flows:       Dictionary of the magnitude of volumetric flow through each connection,
+                                    indexed by connection ID.
+                                    Connection ID in this dictionary is ALWAYS positive, need to take absolute sign of
+                                    the value if it's negative (see `connection_pairing` docstring).
+    """
+    print("Finding connections between compartments")
+
+    # The minimum volumetric flow required between two compartments for a connection to be added between them.
+    flow_threshold          = config_parser.get_item(['COMPARTMENT MODELLING', 'flow_threshold'],       float)
+    # The minimum volumetric flow through a facet for it to considered, facets with flow below this amount are removed.
+    flow_threshold_facet    = config_parser.get_item(['COMPARTMENT MODELLING', 'flow_threshold_facet'], float)
+    log_folder_path         = config_parser.get_item(['SETUP',                 'log_folder_path'],      str)
+    DEBUG                   = config_parser.get_item(['SETUP',                 'DEBUG'],                bool)
+
+    # Dictionary used to store the merged connection information
+    connection_distances: Dict[int, Dict[int, float]] = dict()
+    # Dictionary storing info about which other compartments a given compartment is connected to
+    connection_pairing:   Dict[int, Dict[int, int]]   = dict()
+    volumetric_flows:     Dict[int, float]            = dict()
+
+    # ID to use for the next connection
+    # NOTE: Does not start indexing at 0 so that negative and positive signs can be used as signifier of inlet/outlet
+    id_of_next_connection = 1
+
+    # Lookup for center of fluxes
+    #   The center of flux is calculated as the weight average position of each flux facet
+    #   The weighting is the fraction of the total flux that comes through each facet
+    #   The position of each facet is the mean of all of its vertices
+    centers_of_flow_for_connection: Dict[int, np.ndarray] = dict()
+    with open(log_folder_path + 'connect' + ('' if final else '_for_merge') + '.txt', 'w') as logging:
+        # Calculate the number of connections between compartments and their locations
+        for id_compartment in compartment_network:
+            # Inlets and outlets for this compartment.
+            #   Key is connection ID, value is the ID of the other compartment
+            #   A negative key represents an outlet and a positive an inlet
+            compartment_connections: Dict[int, int] = dict()
+
+            # Calculate flowrate, center of flow, and inlet/outlet status for all connection for this compartment
+            for neighbour in compartment_network[id_compartment]:
+                # Iterate over all of connection_pairing and grab all connections from there
+                id_connections_for_compartment_neighbour_pair: List[int] = []
+                if id_compartment in connection_pairing.get(neighbour, {}).values():
+                    for _id_connection, _id_compartment in connection_pairing.get(neighbour, {}).items():
+                        if _id_compartment == id_compartment:
+                            # If connection was an inlet to the other compartment, it's an outlet to this one.
+                            id_connections_for_compartment_neighbour_pair.append(-_id_connection)
+                            # Do not exit early since there could be multiple connections
+
+                if len(id_connections_for_compartment_neighbour_pair) > 0:  # This pairing already processed, grab data
+                    for id_connection in id_connections_for_compartment_neighbour_pair:
+                        compartment_connections[id_connection] = neighbour
+                else:
+                    """
+                    1. Calculate and store the flowrate through each facet.
+                    2. Calculate the total flowrate with all facets.
+                    3. If it's below the total flow threshold, delete this connection and stop.
+                    4. Mark and remove all facets which are below the individual flow threshold.
+                    5. Calculate the total flowrate with the remaining facets
+                    6. Split the surface into contiguous blocks with the same sign (inlet/outlet)
+                    7. For each resulting contiguous surface calculate the total flowrate through it and if its an inlet/outlet
+                       - Calculate the fraction of the total flow remaining (the total flow obtained) passing through each surface
+                       - Multiply that fraction by the total flowrate obtained when ALL edges are considered.
+                       - NOTE: This is done is order for mass to be better conserved.
+                    8. Calculate the center of flow for each surface.
+                    9. Store the results
+                    """
+                    neighbour_dict: Dict[int, Tuple[int, np.ndarray]] = compartment_network[id_compartment][neighbour]
+
+                    ###
+                    # 1. Calculate and store the flowrate through each facet.
+                    ###
+                    flow_through_facet: Dict[int, float] = dict()
+                    for id_facet in neighbour_dict:
+                        element_on_this_side_of_bound_id, normal = neighbour_dict[id_facet]
+                        velocity_vector = vel_vec[element_on_this_side_of_bound_id]
+                        flux = np.dot(velocity_vector, normal)
+                        flow_through_facet[id_facet] = flux * mesh.facet_size[id_facet]
+
+                    ###
+                    # 2. Calculate the total flowrate with all facets.
+                    ###
+                    total_flow = sum(flow_through_facet.values())
+
+                    ###
+                    # 3. If it's below the total flow threshold, delete this connection and stop.
+                    ###
+                    if final and np.abs(total_flow) < flow_threshold:
+                        continue
+
+                    ###
+                    # 4. Mark and remove all facets which are below the individual flow threshold.
+                    ###
+                    for id_facet in list(flow_through_facet.keys()):
+                        if np.abs(flow_through_facet[id_facet]) < flow_threshold_facet:
+                            flow_through_facet.pop(id_facet)
+
+                    ###
+                    # 5. Calculate the total flowrate with the remaining facets
+                    ###
+                    total_flow_thresholded = sum(flow_through_facet.values())
+
+                    ###
+                    # 6. Split the surface into contiguous blocks with the same sign (inlet/outlet)
+                    ###
+                    # NOTE: One potential issue to look out for is that this may result a single surface being broken up
+                    #       into many tiny surfaces.
+                    inlet_facets: Set[int] = set()
+                    outlet_facet: Set[int] = set()
+                    for id_facet, flow_value in flow_through_facet.items():
+                        # Flow calculated with normal facing out of the compartment
+                        # Negative values are in the opposite direction of the
+                        if flow_value < 0:
+                            inlet_facets.add(id_facet)
+                        else:
+                            outlet_facet.add(id_facet)
+
+                    surfaces: List[List[int]] = []
+                    surfaces.extend(_group_facets_into_surfaces(inlet_facets, mesh))
+                    surfaces.extend(_group_facets_into_surfaces(outlet_facet, mesh))
+
+                    ###
+                    # 7. For each resulting contiguous surface calculate the total flowrate through it and if its an inlet/outlet
+                    ###
+                    flow_through_surfaces: Dict[int, float] = {}
+                    for i, surface in enumerate(surfaces):
+                        flow_through_surfaces[i] = sum(flow_through_facet[id_facet] for id_facet in surface) * total_flow / total_flow_thresholded
+
+                    ###
+                    #  8. Calculate the center of flow for each surface.
+                    #  9. Store the results
+                    ###
+                    for i, flowrate in flow_through_surfaces.items():
+                        if final:
+                            center_of_flow = np.sum([abs(flow_through_facet[facet]) * mesh.facet_centers[facet] for facet in surfaces[i]], 0)
+                            center_of_flow /= abs(flow_through_surfaces[i])
+
+                            centers_of_flow_for_connection[id_of_next_connection] = center_of_flow
+                            volumetric_flows[id_of_next_connection] = abs(flowrate)
+
+                        if flowrate < 0:  # Inlet
+                            compartment_connections[id_of_next_connection] = neighbour
+                        else:  # Outlet
+                            compartment_connections[-id_of_next_connection] = neighbour
+                        id_of_next_connection += 1
+
+            if final:
+                # Must have at least one inlet or outlet. Otherwise, something has gone horrible wrong.
+                assert len(compartment_connections) > 1
+
+                # Calculate average direction
+                avg_direction = np.mean(dir_vec[sorted(compartments[id_compartment])], 0)
+                avg_direction /= np.linalg.norm(avg_direction)
+                if DEBUG:
+                    logging.write(f"avg_direction {id_compartment} = {avg_direction}\n")
+
+                # Calculate the ordering of the inlets/outlets
+                # Project centers of flux onto average direction
+                # Min and max values for normalizing between 0.0 and 1.0
+                # (setting to inf and -inf so that the min and max always work).
+                dot_min, dot_max = np.inf, -np.inf
+                connections_distances_i: Dict[int, float] = dict()
+                for id_connection in compartment_connections:
+                    center_of_flow = centers_of_flow_for_connection[abs(id_connection)]
+                    dot_val = avg_direction.dot(center_of_flow)
+
+                    dot_min, dot_max = min(dot_min, dot_val), max(dot_max, dot_val)
+                    connections_distances_i[id_connection] = dot_val
+
+                # Normalize between 0.0 and 1.0
+                delta_dot = dot_max - dot_min
+                for id_connection in connections_distances_i:
+                    connections_distances_i[id_connection] = (connections_distances_i[id_connection] - dot_min) / delta_dot
+
+                connection_distances[id_compartment] = connections_distances_i
+            connection_pairing[id_compartment] = compartment_connections
+
+        if DEBUG:
+            logging.write("id_of_next_connection: {}\n".format(id_of_next_connection))
+            logging.write("connection_pairing: {}\n".format(connection_pairing))
+            logging.write("compartment_network: {}\n".format(compartment_network))
+            logging.write("compartments: {}\n".format(compartments))
+            logging.write("volumetric_flows: {}\n".format(volumetric_flows))
+
+    print("Done finding connections between compartments")
+    return id_of_next_connection, connection_distances, connection_pairing, compartment_network, compartments, volumetric_flows
+
+
+def _group_facets_into_surfaces(facets: Set[int], mesh: CMesh) -> List[List[int]]:
+    """
+    Take a set of facets and group them together into several contiguous surfaces.
+
+    Facets are considered as being connected if they share one entity of a dimension lower than them.
+    E.g. For a 3D mesh, facets are surfaces. Two facets are considered connected if they share an edge.
+    The creation of this connectivity is handled by the creation of the CMesh.
+    This function queries the CMesh for which facet(s) a given facet is connected it.
+
+    Args:
+        facets: The set of facets to group.
+        mesh:   The CMesh on which the facets below. Used to get their connectivity.
+
+    Returns:
+        surfaces:   A list of contiguous surfaces, each represented as a list of facet IDs.
+
+    """
+    surfaces: List[List[int]] = []
+
+    while len(facets) > 0:
+        new_surface = [facets.pop()]
+        # The facet(s) last added to the compartment and whose connected facet must now be checked
+        facet_ids_to_check = {new_surface[0]}
+
+        while True:
+            neighbours = set()
+            # Get all the neighbours of the current facet
+            for facet in facet_ids_to_check:
+                neighbours.update(neighbour_facet for neighbour_facet in mesh.facet_connectivity[facet])
+
+            # Remove all those that are not available (have already been added or where never part of the set)
+            neighbours_to_add = facets.intersection(neighbours)
+
+            if len(neighbours_to_add) == 0:
+                break
+            else:
+                facet_ids_to_check = neighbours_to_add
+                new_surface.extend(neighbours_to_add)
+                facets.difference_update(neighbours_to_add)
+
+        surfaces.append(new_surface)
+
+    return surfaces

--- a/openccm/compartmentalize/__init__.py
+++ b/openccm/compartmentalize/__init__.py
@@ -15,5 +15,4 @@
 # <https://www.gnu.org/licenses/>.                                                                                     #
 ########################################################################################################################
 
-from .unidirectional import calculate_compartments, connect_compartments_using_unidirectional_assumptions, \
-                            create_compartment_network
+from .unidirectional import calculate_compartments, create_compartment_network

--- a/openccm/compartmentalize/unidirectional.py
+++ b/openccm/compartmentalize/unidirectional.py
@@ -357,7 +357,8 @@ def merge_compartments(compartments:        Dict[int, Set[int]],
     num_pre_merge = len(compartments)
 
     # Calculate the average direction vector for each compartment
-    compartment_avg_directions = np.zeros((max(compartments.keys()) + 1, dir_vec.shape[1]))
+    # Note that compartment IDs cannot be assumed to be an uninterupted sequence from 0 to max(compartment.keys())
+    compartment_avg_directions = np.inf * np.ones((max(compartments.keys()) + 1, dir_vec.shape[1]))
     for i_compartment in compartments:
         compartment_avg_directions[i_compartment, :] = np.mean(dir_vec[list(compartments[i_compartment]), :], axis=0)
     magnitude = np.linalg.norm(compartment_avg_directions, axis=1)[:, np.newaxis]

--- a/openccm/compartmentalize/unidirectional.py
+++ b/openccm/compartmentalize/unidirectional.py
@@ -78,9 +78,8 @@ def create_compartment_network(compartments:    Dict[int, Set[int]],
             element_to_compartment_map[element] = id_compartment
 
     # Add BCs to the element compartment_map
-    for _id in mesh.grouped_bcs.domain_inlets + mesh.grouped_bcs.domain_outlets + mesh.grouped_bcs.ignored:
+    for _id in mesh.grouped_bcs.domain_inlets + mesh.grouped_bcs.domain_outlets + mesh.grouped_bcs.ignored + (mesh.grouped_bcs.no_flux,):
         element_to_compartment_map[_id] = _id
-    element_to_compartment_map[mesh.grouped_bcs.no_flux] = mesh.grouped_bcs.no_flux
 
     with open(log_folder_path + "network.txt", 'w') as logging:
         # Group the bounding entities of this compartment based on the compartment on the other side of them
@@ -99,7 +98,7 @@ def create_compartment_network(compartments:    Dict[int, Set[int]],
                 # If the facet is on the bounds of the mesh, then the element_id will be negative
                 element_on_other_side_of_bound = bounding_facets_info[facet][1]
 
-                if element_on_other_side_of_bound == mesh.grouped_bcs.no_flux or \
+                if element_on_other_side_of_bound == mesh.grouped_bcs.no_flux or element_on_other_side_of_bound in mesh.grouped_bcs.ignored or \
                         element_on_other_side_of_bound not in element_to_compartment_map:
                     bounding_facets_info.pop(facet)
 
@@ -350,8 +349,8 @@ def merge_compartments(compartments:        Dict[int, Set[int]],
         assert len(network) > 0
         assert compartment_id not in network
 
-    DEBUG                = config_parser.get_item(['SETUP',                'DEBUG'],                bool)
-    log_folder_path      = config_parser.get_item(['SETUP',                'log_folder_path'],      str)
+    DEBUG                = config_parser.get_item(['SETUP',                 'DEBUG'],                bool)
+    log_folder_path      = config_parser.get_item(['SETUP',                 'log_folder_path'],      str)
     # The minimum size of a compartment. Units are the same as those used by the mesh.
     min_compartment_size = config_parser.get_item(['COMPARTMENTALIZATION',  'min_compartment_size'], float)
     model                = config_parser.get_item(['COMPARTMENT MODELLING', 'model'],                str)
@@ -387,16 +386,6 @@ def merge_compartments(compartments:        Dict[int, Set[int]],
     else:
         raise ValueError(f"Unsupported model type: {model}")
 
-    # Remove all connections that lead to a BC since we do not want to consider them for the purpose of merging compartments
-    for _id_pfr_tmp in connection_pairing:
-        _connections_for_pfr = connection_pairing[_id_pfr_tmp]
-        for i_connection in list(_connections_for_pfr.keys()):  # Need to make the copy with list() since we're modifying the dict during the loop
-            if _connections_for_pfr[i_connection] < 0:  # Negative PFR if represents a
-                _connections_for_pfr.pop(i_connection)
-        # If there are no connections available after removing the domain boundaries, then this compartment cannot be merged with something else
-        if len(_connections_for_pfr) == 0:
-            # Setting to infinite so that a numpy array indexed by compartment id can be used
-            compartment_sizes[_id_pfr_tmp] = np.inf
     with open(log_folder_path + "merge.txt", 'w') as logging:
         if DEBUG:
             logging.write("[ Pre\n")
@@ -405,70 +394,48 @@ def merge_compartments(compartments:        Dict[int, Set[int]],
             logging.write("]\n")
             logging.write("[ Merging\n")
 
-        # Iterate over compartments, and merge together any that only have one connection.
+        # Merge all compartments which have only one neighbour or all inlets/outlet.
         # At this point it is possible for compartments to have a single connection.
         # Only after the network has been built is it guaranteed that each compartment has at least 2 connections.
-        compartments_with_one_connection = set()
-        for id_compartment, network in compartment_network.items():
-            if len(network) <= 1:
-                compartments_with_one_connection.add(id_compartment)
-        while len(compartments_with_one_connection) > 0:
-            id_compartment = compartments_with_one_connection.pop()
-            keys = list(compartment_network[id_compartment].keys())
-            assert len(keys) == 1
-            id_merge_into = keys[0]
-            if id_merge_into in compartments_with_one_connection:
-                raise AssertionError(f"Compartments {id_compartment} and {id_merge_into} are only connected to each other.")
+        compartments_to_merge = set()
+        for id_compartment, connections in connection_pairing.items():
+            if len(connections) <= 1:
+                compartments_to_merge.add(id_compartment)
+            elif all_connections_of_same_type(connections):
+                compartments_to_merge.add(id_compartment)
+        while len(compartments_to_merge) > 0:
+            id_compartment = compartments_to_merge.pop()
+            if len(connection_pairing[id_compartment]) == 1:
+                id_merge_into = list(compartment_network[id_compartment].keys())[0]
+                if id_merge_into in compartments_to_merge and len(compartment_network[id_merge_into]) == 1:
+                    raise AssertionError(f"Compartments {id_compartment} and {id_merge_into} are only connected to each other.")
+            elif all_connections_of_same_type(connection_pairing[id_compartment]):
+                id_merge_into = find_best_merge_target(id_compartment, connection_pairing[id_compartment],
+                                                       compartment_avg_directions)
+            else:
+                pass  # A previous run of _merge_two_compartments merged into one or more compartments into this one
 
             _merge_two_compartments(id_merge_into, id_compartment, compartments, compartment_network,
                                     compartment_sizes, connection_pairing, compartment_avg_directions,
-                                    dir_vec)
+                                    dir_vec, volumetric_flows, cstr=(model=='cstr'))
 
         while np.any(compartment_sizes < min_compartment_size):
-            # Find the smallest compartment
             id_smallest: int = np.argmin(compartment_sizes)
             if DEBUG: logging.write("smallest: {} ".format(id_smallest))
-            compartment_value = compartment_avg_directions[id_smallest]
-            """
-            1. Filter those which do not have the flow in the correct direction
-                1.1. If possible, merge only into downstream compartments (ones with negative connection id)
-                1.2. If 1.1. is not possible, merge into an upstream compartment but print info
-            """
-            # keys are connection id, negative means that the connection is an outlet (and thus the other compartment is downstream of this one)
-            # Values are compartment on the other side of the connection
-            connections = connection_pairing[id_smallest]
 
-            # Find all connections which lead to a downstream compartment
-            downstream_connection_ids = []
-            for i_connection in connections:
-                if i_connection < 0:
-                    downstream_connection_ids.append(i_connection)
-
-            if len(downstream_connection_ids) > 0:
-                # 1.1. If possible, merge only into downstream compartments (ones with negative connection id)
-                id_neighbour_compartment = [connections[i_connection] for i_connection in downstream_connection_ids]
-            else:
-                # 1.2. If 1.1. is not possible, merge into an upstream compartment but print info
-                id_neighbour_compartment = list(connections.values())
-                print("Had to merge compartment {} into an upstream compartment since there were no downstream compartments".format(id_smallest))
-
-            neighbour_values = compartment_avg_directions[id_neighbour_compartment]
-
-            # 2. Pick the ones with the closest direction
-            dot_products = neighbour_values.dot(compartment_value)
-            id_merge_into = id_neighbour_compartment[np.argmax(dot_products)]
-
+            id_merge_into = find_best_merge_target(id_smallest, connection_pairing[id_smallest], compartment_avg_directions)
             if DEBUG: logging.write("merged into: {}\n".format(id_merge_into))
-            # Merge this compartment with its neighbour
+
             _merge_two_compartments(id_merge_into, id_smallest, compartments, compartment_network,
                                     compartment_sizes, connection_pairing, compartment_avg_directions,
-                                    dir_vec)
+                                    dir_vec, volumetric_flows, cstr=(model=='cstr'))
 
         if DEBUG: logging.write("]\n")
 
         # Check compartments
         for compartment_id, network in compartment_network.items():
             assert len(network) > 1
+            assert not all_connections_of_same_type(connection_pairing[compartment_id])
             assert compartment_id not in network
 
         if DEBUG:
@@ -491,247 +458,44 @@ def merge_compartments(compartments:        Dict[int, Set[int]],
     print("Done merging compartments")
 
 
-def connect_compartments_using_unidirectional_assumptions(compartment_network:  Dict[int, Dict[int, Dict[int, Tuple[int, np.ndarray]]]],
-                                                          compartments:         Dict[int, Set[int]],
-                                                          mesh:                 CMesh,
-                                                          dir_vec:              np.ndarray,
-                                                          vel_vec:              np.ndarray,
-                                                          final:                bool,
-                                                          config_parser:        ConfigParser) \
-        -> Tuple[int,
-                 Dict[int, Dict[int, float]],
-                 Dict[int, Dict[int, int]],
-                 Dict[int, Dict[int, Dict[int, Tuple[int, np.ndarray]]]],
-                 Dict[int, Set[int]],
-                 Dict[int, float]]:
+def find_best_merge_target(id_to_merge, connections, compartment_avg_directions):
     """
-    Function to take a compartment network and compartments and create the connections between them.
-    Calculates the flowrates and direction of flow between connected compartments.
-    CAN RETURN MULTIPLE CONNECTIONS BETWEEN TWO COMPARTMENTS.
-
-    A surface shared by two compartments is made up of facets, all facets below the specified threshold
-    (flow_threshold_i) are removed from the surface.
-    Then the surface is split into contiguous subsurfaces which all have the same direction of flow.
-    Each subsurface is treated as a separate connection between the two compartments that it's between.
+    Identify which of id_to_merge's neighbours it should be merged into.
+    Criteria used:
+        1. Compartment should be downstream of id_to_merge into
+        2. Compartment with the closest average direction vector is chosen.
 
     Args:
-        compartment_network:    A dictionary representation of the compartments in the network.
-                                Keys are compartment IDs, and whose values are dictionary.
-                                    For each of those dictionaries, the keys are the index of a neighboring compartment
-                                    and the values are another dictionary.
-                                        For each of those dictionaries, the keys are the index of the bounding facet
-                                        between the two compartments, and the values Tuples.
-                                            - The first entry in the tuple is the index of the element
-                                              on the boundary inside the compartment.
-                                            - The second entry in the tuple is a numpy array representing
-                                              the unit normal for that boundary facing out of the compartment.
-        compartments:           A dictionary representation of the elements in the compartments.
-                                Keys are compartment IDs, values are sets containing the indices
-                                of the elements in the compartment.
-        mesh:                   The mesh the problem was solved on.
-        dir_vec:                Numpy array of direction vectors, row i is for element i.
-        vel_vec:                Numpy array of velocity vectors, row i is for element i.
-        final:                  If asserts and all calculations should be performed.
-                                This is set to True when function is called from merge_compartments since some may
-                                be too small for the invariants to be true.
-        config_parser:          The OpenCCM ConfigParser
+        id_to_merge:                    ID of the compartment to merge.
+        connections:                    The connections
+        compartment_avg_directions:
 
     Returns:
-        Tuple of two values:
-            id_next_connection:     The integer to use for the next connection ID.
-            connection_distances:   Dictionary storing the distance.
-            connection_pairing:     Dictionary storing info about which other compartments a given compartment is connected to.
-                                        - First key is compartment ID
-                                        - Values is a Dict[int, int]
-                                            - Key is connection ID (positive inlet into this compartment, negative is outlet)
-                                            - Value is the ID of the compartment on the other side
-            compartment_network:    The compartment network passed in.
-            compartments            The compartments passed in.
-            volumetric_flows:       Dictionary of the magnitude of volumetric flow through each connection,
-                                    indexed by connection ID.
-                                    Connection ID in this dictionary is ALWAYS positive, need to take absolute sign of
-                                    the value if it's negative (see `connection_pairing` docstring).
+        id_merge_into:                   ID of the compartment to merge into.
     """
-    print("Finding connections between compartments")
+    compartment_value = compartment_avg_directions[id_to_merge]
 
-    # The minimum volumetric flow required between two compartments for a connection to be added between them.
-    flow_threshold          = config_parser.get_item(['COMPARTMENT MODELLING', 'flow_threshold'],       float)
-    # The minimum volumetric flow through a facet for it to considered, facets with flow below this amount are removed.
-    flow_threshold_facet    = config_parser.get_item(['COMPARTMENT MODELLING', 'flow_threshold_facet'], float)
-    log_folder_path         = config_parser.get_item(['SETUP',                 'log_folder_path'],      str)
-    DEBUG                   = config_parser.get_item(['SETUP',                 'DEBUG'],                bool)
+    # 1. Filter search, if possible, to compartments downstream of id_to_merge
+    downstream_connection_ids = []
+    for connection, compartment in connections.items():
+        if connection < 0 and compartment > 0:
+            downstream_connection_ids.append(connection)
+    if len(downstream_connection_ids) > 0:
+        id_neighbour_compartment = [connections[i_connection] for i_connection in downstream_connection_ids]
+    else:
+        id_neighbour_compartment = list(filter(lambda compartment: compartment > 0, connections.values()))
+        print(f"No downstream compartments for {id_to_merge}, merging upstream.")
 
-    # Dictionary used to store the merged connection information
-    connection_distances: Dict[int, Dict[int, float]] = dict()
-    # Dictionary storing info about which other compartments a given compartment is connected to
-    connection_pairing:   Dict[int, Dict[int, int]]   = dict()
-    volumetric_flows:     Dict[int, float]            = dict()
+    # 2. Pick the ones with the closest average direction vector
+    neighbour_values = compartment_avg_directions[id_neighbour_compartment]
+    dot_products     = neighbour_values.dot(compartment_value)
+    id_merge_into    = id_neighbour_compartment[np.argmax(dot_products)]
+    return id_merge_into
 
-    # ID to use for the next connection
-    # NOTE: Does not start indexing at 0 so that negative and positive signs can be used as signifier of inlet/outlet
-    id_of_next_connection = 1
 
-    # Lookup for center of fluxes
-    #   The center of flux is calculated as the weight average position of each flux facet
-    #   The weighting is the fraction of the total flux that comes through each facet
-    #   The position of each facet is the mean of all of its vertices
-    centers_of_flow_for_connection: Dict[int, np.ndarray] = dict()
-    with open(log_folder_path + 'connect' + ('' if final else '_for_merge') + '.txt', 'w') as logging:
-        # Calculate the number of connections between compartments and their locations
-        for id_compartment in compartment_network:
-            # Inlets and outlets for this compartment.
-            #   Key is connection ID, value is the ID of the other compartment
-            #   A negative key represents an outlet and a positive an inlet
-            compartment_connections: Dict[int, int] = dict()
-
-            # Calculate flowrate, center of flow, and inlet/outlet status for all connection for this compartment
-            for neighbour in compartment_network[id_compartment]:
-                # Iterate over all of connection_pairing and grab all connections from there
-                id_connections_for_compartment_neighbour_pair: List[int] = []
-                if id_compartment in connection_pairing.get(neighbour, {}).values():
-                    for _id_connection, _id_compartment in connection_pairing.get(neighbour, {}).items():
-                        if _id_compartment == id_compartment:
-                            # If connection was an inlet to the other compartment, it's an outlet to this one.
-                            id_connections_for_compartment_neighbour_pair.append(-_id_connection)
-                            # Do not exit early since there could be multiple connections
-
-                if len(id_connections_for_compartment_neighbour_pair) > 0:  # This pairing already processed, grab data
-                    for id_connection in id_connections_for_compartment_neighbour_pair:
-                        compartment_connections[id_connection] = neighbour
-                else:
-                    """
-                    1. Calculate and store the flowrate through each facet.
-                    2. Calculate the total flowrate with all facets.
-                    3. If it's below the total flow threshold, delete this connection and stop.
-                    4. Mark and remove all facets which are below the individual flow threshold.
-                    5. Calculate the total flowrate with the remaining facets
-                    6. Split the surface into contiguous blocks with the same sign (inlet/outlet)
-                    7. For each resulting contiguous surface calculate the total flowrate through it and if its an inlet/outlet
-                       - Calculate the fraction of the total flow remaining (the total flow obtained) passing through each surface
-                       - Multiply that fraction by the total flowrate obtained when ALL edges are considered.
-                       - NOTE: This is done is order for mass to be better conserved.
-                    8. Calculate the center of flow for each surface.
-                    9. Store the results
-                    """
-                    neighbour_dict: Dict[int, Tuple[int, np.ndarray]] = compartment_network[id_compartment][neighbour]
-
-                    ###
-                    # 1. Calculate and store the flowrate through each facet.
-                    ###
-                    flow_through_facet: Dict[int, float] = dict()
-                    for id_facet in neighbour_dict:
-                        element_on_this_side_of_bound_id, normal = neighbour_dict[id_facet]
-                        velocity_vector = vel_vec[element_on_this_side_of_bound_id]
-                        flux = np.dot(velocity_vector, normal)
-                        flow_through_facet[id_facet] = flux * mesh.facet_size[id_facet]
-
-                    ###
-                    # 2. Calculate the total flowrate with all facets.
-                    ###
-                    total_flow = sum(flow_through_facet.values())
-
-                    ###
-                    # 3. If it's below the total flow threshold, delete this connection and stop.
-                    ###
-                    if final and np.abs(total_flow) < flow_threshold:
-                        continue
-
-                    ###
-                    # 4. Mark and remove all facets which are below the individual flow threshold.
-                    ###
-                    for id_facet in list(flow_through_facet.keys()):
-                        if np.abs(flow_through_facet[id_facet]) < flow_threshold_facet:
-                            flow_through_facet.pop(id_facet)
-
-                    ###
-                    # 5. Calculate the total flowrate with the remaining facets
-                    ###
-                    total_flow_thresholded = sum(flow_through_facet.values())
-
-                    ###
-                    # 6. Split the surface into contiguous blocks with the same sign (inlet/outlet)
-                    ###
-                    # NOTE: One potential issue to look out for is that this may result a single surface being broken up
-                    #       into many tiny surfaces.
-                    inlet_facets: Set[int] = set()
-                    outlet_facet: Set[int] = set()
-                    for id_facet, flow_value in flow_through_facet.items():
-                        # Flow calculated with normal facing out of the compartment
-                        # Negative values are in the opposite direction of the
-                        if flow_value < 0:
-                            inlet_facets.add(id_facet)
-                        else:
-                            outlet_facet.add(id_facet)
-
-                    surfaces: List[List[int]] = []
-                    surfaces.extend(_group_facets_into_surfaces(inlet_facets, mesh))
-                    surfaces.extend(_group_facets_into_surfaces(outlet_facet, mesh))
-
-                    ###
-                    # 7. For each resulting contiguous surface calculate the total flowrate through it and if its an inlet/outlet
-                    ###
-                    flow_through_surfaces: Dict[int, float] = {}
-                    for i, surface in enumerate(surfaces):
-                        flow_through_surfaces[i] = sum(flow_through_facet[id_facet] for id_facet in surface) * total_flow / total_flow_thresholded
-
-                    ###
-                    #  8. Calculate the center of flow for each surface.
-                    #  9. Store the results
-                    ###
-                    for i, flowrate in flow_through_surfaces.items():
-                        if final:
-                            center_of_flow = np.sum([abs(flow_through_facet[facet]) * mesh.facet_centers[facet] for facet in surfaces[i]], 0)
-                            center_of_flow /= abs(flow_through_surfaces[i])
-
-                            centers_of_flow_for_connection[id_of_next_connection] = center_of_flow
-                            volumetric_flows[id_of_next_connection] = abs(flowrate)
-
-                        if flowrate < 0:  # Inlet
-                            compartment_connections[id_of_next_connection] = neighbour
-                        else:  # Outlet
-                            compartment_connections[-id_of_next_connection] = neighbour
-                        id_of_next_connection += 1
-
-            if final:
-                # Must have at least one inlet or outlet. Otherwise, something has gone horrible wrong.
-                assert len(compartment_connections) > 1
-
-                # Calculate average direction
-                avg_direction = np.mean(dir_vec[sorted(compartments[id_compartment])], 0)
-                avg_direction /= np.linalg.norm(avg_direction)
-                if DEBUG:
-                    logging.write(f"avg_direction {id_compartment} = {avg_direction}\n")
-
-                # Calculate the ordering of the inlets/outlets
-                # Project centers of flux onto average direction
-                # Min and max values for normalizing between 0.0 and 1.0
-                # (setting to inf and -inf so that the min and max always work).
-                dot_min, dot_max = np.inf, -np.inf
-                connections_distances_i: Dict[int, float] = dict()
-                for id_connection in compartment_connections:
-                    center_of_flow = centers_of_flow_for_connection[abs(id_connection)]
-                    dot_val = avg_direction.dot(center_of_flow)
-
-                    dot_min, dot_max = min(dot_min, dot_val), max(dot_max, dot_val)
-                    connections_distances_i[id_connection] = dot_val
-
-                # Normalize between 0.0 and 1.0
-                delta_dot = dot_max - dot_min
-                for id_connection in connections_distances_i:
-                    connections_distances_i[id_connection] = (connections_distances_i[id_connection] - dot_min) / delta_dot
-
-                connection_distances[id_compartment] = connections_distances_i
-            connection_pairing[id_compartment] = compartment_connections
-
-        if DEBUG:
-            logging.write("id_of_next_connection: {}\n".format(id_of_next_connection))
-            logging.write("connection_pairing: {}\n".format(connection_pairing))
-            logging.write("compartment_network: {}\n".format(compartment_network))
-            logging.write("compartments: {}\n".format(compartments))
-            logging.write("volumetric_flows: {}\n".format(volumetric_flows))
-
-    print("Done finding connections between compartments")
-    return id_of_next_connection, connection_distances, connection_pairing, compartment_network, compartments, volumetric_flows
+def all_connections_of_same_type(network: Dict[int, int]):
+    keys = list(network.keys())
+    return all((x >= 0) == (keys[0] >= 0) for x in keys)
 
 
 def _calculate_compartments(elements_not_in_a_compartment:  Set[int],
@@ -1018,12 +782,14 @@ def _merge_two_compartments(id_merge_into:              int,
                             compartment_sizes:          np.ndarray,
                             connection_pairing:         Dict[int, Dict[int, int]],
                             compartment_avg_directions: np.ndarray,
-                            dir_vec:                    np.ndarray) -> None:
+                            dir_vec:                    np.ndarray,
+                            volumetric_flows:           Dict[int, float],
+                            cstr:                       bool) -> None:
     """
     Helper function to perform the merging of two compartments and update the relevant places.
 
-    If merging these two compartments would result in another compartment having a single neighbour the function
-    will merge that other compartment too.
+    If merging these two compartments would result in another compartment having a single neighbour, or having
+    connections of only one type (i.e. all inlets or all outlets), the function will merge that other compartment too.
     This process will iterate until all compartments connected to id_merge_into and id_to_merge have more than
     one neighbour.
 
@@ -1051,7 +817,8 @@ def _merge_two_compartments(id_merge_into:              int,
         compartment_avg_directions: Average direction vector for each compartment, indexed by compartment ID.
         dir_vec:                    Direction vector for each compartment, indexed by compartment ID.
     """
-    compartments_with_one_connections = set()
+    def sign(x): return 1 if x > 0 else -1
+    compartments_to_merge = set()
 
     # Merging two compartments can result in one of their neighbours now having a single neighbour.
     # We will keep iterating and merging until there are no such neighbours left
@@ -1067,15 +834,36 @@ def _merge_two_compartments(id_merge_into:              int,
 
         # Update connections between compartments
         for id_connection in list(connection_pairing[id_to_merge].keys()):
-            # Remove entries from under id_smallest
+            # Remove entries from under id_to_merge
             id_neighbour = connection_pairing[id_to_merge].pop(id_connection)
             if id_neighbour == id_merge_into:
-                # Remove the entry for id_smallest from id_merge_into's dict
+                # Remove the entry for id_to_merge from id_merge_into's dict
                 connection_pairing[id_merge_into].pop(-id_connection)
-            else:
+            elif id_neighbour >= 0:
                 # Take all connections with other compartments and hook them up to id_merge_into
                 connection_pairing[id_merge_into][id_connection] = id_neighbour
                 connection_pairing[id_neighbour][-id_connection] = id_merge_into
+
+                if cstr:  # Combine multiple connections into one
+                    shared_connections = [connection for connection, _neighbour in connection_pairing[id_merge_into].items() if _neighbour == id_neighbour]
+                    if len(shared_connections) > 1:
+                        net_flow_into_id_merge_into = sum(sign(connection) * volumetric_flows[abs(connection)] for connection in shared_connections)
+
+                        for connection in shared_connections:
+                            connection_pairing[id_merge_into].pop(connection)
+                            connection_pairing[id_neighbour].pop(-connection)
+                            volumetric_flows.pop(abs(connection))
+
+                        # Reuse the first connection
+                        _id_connection = sign(net_flow_into_id_merge_into) * abs(shared_connections[0])
+                        volumetric_flows[abs(shared_connections[0])] = abs(net_flow_into_id_merge_into)
+
+                        # Positive connection means an inlet for this connection
+                        connection_pairing[id_merge_into][_id_connection] = id_neighbour
+                        connection_pairing[id_neighbour] [-_id_connection] = id_merge_into
+
+                if len(connection_pairing[id_neighbour]) == 1 or all_connections_of_same_type(connection_pairing[id_neighbour]):
+                    compartments_to_merge.add(id_neighbour)
 
         assert len(connection_pairing[id_to_merge]) == 0
         connection_pairing.pop(id_to_merge)
@@ -1113,25 +901,26 @@ def _merge_two_compartments(id_merge_into:              int,
             # Update information in id_neighbour to point to id_merge_into instead of id_to_merge
             # But only do so if id_neighbour is not a mesh boundary
             if id_neighbour >= 0:
+                # This keeps a single contiguous surface for each pairing, so no duplicates to get rid of like for connection_pairings
                 compartment_network[id_neighbour][id_merge_into] = {**compartment_network[id_neighbour][id_merge_into],
                                                                     **compartment_network[id_neighbour].pop(id_to_merge)}
-
-                if len(compartment_network[id_neighbour]) == 1:
-                    compartments_with_one_connections.add(id_neighbour)
 
         # Remove the merged compartment from the network
         compartment_network.pop(id_to_merge)
 
-        if len(compartment_network[id_merge_into]) == 1:
-            compartments_with_one_connections.add(id_merge_into)
+        if len(connection_pairing[id_merge_into]) == 1  or all_connections_of_same_type(connection_pairing[id_merge_into]):
+            compartments_to_merge.add(id_merge_into)
 
-        if len(compartments_with_one_connections) == 0:
+        if len(compartments_to_merge) == 0:
             break  # Only way out of the loop
         else:
-            id_to_merge = compartments_with_one_connections.pop()
-            keys = list(compartment_network[id_to_merge].keys())
-            assert len(keys) == 1
-            id_merge_into = keys[0]
+            id_to_merge = compartments_to_merge.pop()
+            if len(connection_pairing[id_to_merge]) == 1:
+                id_merge_into = list(compartment_network[id_to_merge].keys())[0]
+            elif all_connections_of_same_type(connection_pairing[id_to_merge]):
+                id_merge_into = find_best_merge_target(id_to_merge, connection_pairing[id_to_merge], compartment_avg_directions)
+            else:
+                pass  # Merged INTO it on a previous iteration
 
 
 def _check_flow_requirement(element: int, compartment: Set[int], vec: np.ndarray, mesh: CMesh, flow_threshold: float) -> bool:


### PR DESCRIPTION
1. Change merging of small compartments in order to avoid it creating CSTR compartments with only inlets or only outlets.
2. Move around some parallel functions for PFRs/CSTRs into their respective folders