### PR TITLE
Compartment Merging Improvements

### DIFF
--- a/openccm/compartmentalize/unidirectional.py
+++ b/openccm/compartmentalize/unidirectional.py
@@ -422,7 +422,12 @@ def merge_compartments(compartments:        Dict[int, Set[int]],
 
             _merge_two_compartments(id_merge_into, id_compartment, compartments, compartment_network,
                                     compartment_sizes, connection_pairing, compartment_avg_directions,
-                                    dir_vec, volumetric_flows, cstr=(model=='cstr'))
+                                    dir_vec, volumetric_flows, cstr=(model == 'cstr'))
+
+        # Any compartment connected only to domain inlets/outlets cannot be merged into something else
+        for compartment, connections in connection_pairing.items():
+            if all(neighbour < 0 for neighbour in connections.values()):
+                compartment_sizes[compartment] = np.inf
 
         while np.any(compartment_sizes < min_compartment_size):
             id_smallest: int = np.argmin(compartment_sizes)


### PR DESCRIPTION
1. Compartments which are only connected to domain inlets/outlets are no longer considered for merging since they don't have anything to be merged into. Such compartments can show up in certain flow reactors, but are very rare outside of structured meshes.
2. When calculating connections between compartments, we now keep track of if the connection from A -> B was rejected due to being to small to avoid doing the same calculation when it comes time to evaluate B's connections.