### PR TITLE
Fix implementation of flow optimization

### DIFF
--- a/CONFIG
+++ b/CONFIG
@@ -57,8 +57,7 @@ flow_threshold_facet    = [1e-15]
 flow_threshold          = [1e-15]
 # Maximum allowable difference (in % of compartment volume) between connections for merging them to one location.
 dist_threshold          = [5 / 100]
-# Relative and absolute tolerances for checking that conservation of mass for the liquid after the flow optimization is performed.
-rtol_opt                = [0]
+# Absolute tolerances for checking that conservation of mass for the liquid after the flow optimization is performed.
 atol_opt                = [1e-2]
 
 [SIMULATION]

--- a/openccm/compartment_models/cstr.py
+++ b/openccm/compartment_models/cstr.py
@@ -159,7 +159,6 @@ def create_cstr_network(compartments:           Dict[int, Set[int]],
     """
     print('Creating CSTR network')
 
-    rtol_opt = config_parser.get_item(['COMPARTMENT MODELLING', 'rtol_opt'], float)
     atol_opt = config_parser.get_item(['COMPARTMENT MODELLING', 'atol_opt'], float)
 
     ####################################################################################################################
@@ -206,7 +205,7 @@ def create_cstr_network(compartments:           Dict[int, Set[int]],
         assert len(outlets) > 0
         connections[id_cstr] = (inlets, outlets)
 
-    tweak_final_flows(connections, volumetric_flows, mesh.grouped_bcs, atol_opt, rtol_opt)
+    tweak_final_flows(connections, volumetric_flows, mesh.grouped_bcs, atol_opt)
 
     compartment_to_cstr_map: Dict[int, List[int]] = {cstr: [cstr] for cstr in range(len(connections))}
 

--- a/openccm/compartment_models/pfr.py
+++ b/openccm/compartment_models/pfr.py
@@ -79,7 +79,6 @@ def create_pfr_network(compartments:        Dict[int, Set[int]],
     """
     print("Creating PFR network")
 
-    rtol_opt        = config_parser.get_item(['COMPARTMENT MODELLING', 'rtol_opt'],       float)
     atol_opt        = config_parser.get_item(['COMPARTMENT MODELLING', 'atol_opt'],       float)
     dist_threshold  = config_parser.get_item(['COMPARTMENT MODELLING', 'dist_threshold'], float)
 
@@ -96,7 +95,7 @@ def create_pfr_network(compartments:        Dict[int, Set[int]],
     id_next_connection, connection_distances, connection_pairing, compartment_network, compartments, _volumetric_flows = results_1
 
     # 1.2 Optimize connections to prevent flow reversal when creating the intra-compartment flows.
-    tweak_compartment_flows(connection_pairing, _volumetric_flows, mesh.grouped_bcs, atol_opt, rtol_opt)
+    tweak_compartment_flows(connection_pairing, _volumetric_flows, mesh.grouped_bcs, atol_opt)
 
     # 1.3 Reorder connections and merge their locations as needed.
     connection_locations: Dict[int, List[Tuple[float, List[int]]]] = dict()
@@ -192,7 +191,7 @@ def create_pfr_network(compartments:        Dict[int, Set[int]],
         assert np.all(_outlets < 0) or np.all(_outlets >= 0)
 
     # Final optimization of flowrates in order to ensure mass is conserved around each PFR
-    tweak_final_flows(connections, volumetric_flows, mesh.grouped_bcs, atol_opt, rtol_opt)
+    tweak_final_flows(connections, volumetric_flows, mesh.grouped_bcs, atol_opt)
 
     print("Done creating PFR network")
     return connections, volumes, volumetric_flows, compartment_to_pfr_map

--- a/openccm/config_functions/expanded_config_parser.py
+++ b/openccm/config_functions/expanded_config_parser.py
@@ -39,7 +39,6 @@ config_defaults: Dict = {
     'COMPARTMENT MODELLING': {'flow_threshold': 1e-15,
                               'flow_threshold_facet': 1e-15,
                               'dist_threshold': 5. / 100,
-                              'rtol_opt': 0,
                               'atol_opt': 1e-2},
     'SIMULATION': {'run': True,
                    'points_per_pfr': 2,

--- a/pytests/test_tweak_compartment_flows.py
+++ b/pytests/test_tweak_compartment_flows.py
@@ -60,7 +60,7 @@ def test_tweak_compartment_flows():
     # tweak_compartment_flows modifies in place, make a copy to see before and after
     volumetric_flows_orig = volumetric_flows.copy()
     overall_com_before, compartment_com_before = calculate_com(volumetric_flows_orig, connection_pairings)
-    tweak_compartment_flows(connection_pairings, volumetric_flows, grouped_bcs, atol_opt=1e-2, rtol_opt=0.0)
+    tweak_compartment_flows(connection_pairings, volumetric_flows, grouped_bcs, atol_opt=1e-2)
     overall_com_after,  compartment_com_after  = calculate_com(volumetric_flows, connection_pairings)
 
 


### PR DESCRIPTION
Previously the initial flow optimization in `tweak_compartment_flows` required each compartment have no net outflow and that the net inflow was capped to the user specified $atol_{opt}$. However, it was not enforcing $atol_{opt}$ through the optimization routine, it was only checking against it after the fact. I.e. the constraint was $$\epsilon \le flow_{in} - flow_{out}$$

This PR changes the optimization problem to include that maximum, $atol_{opt}$, as a constraint on each compartment. I.e. each compartment has the following constraints: $$\epsilon \le flow_{in} - flow_{out} \le atol_{opt}$$

It also removes $rtol_{opt}$ since the value being compared against is $0$, thus a relative tolerance isn't needed.