### PR TITLE
Fixes for no-flux BCs

### DIFF
--- a/openccm/compartment_models/helpers.py
+++ b/openccm/compartment_models/helpers.py
@@ -29,6 +29,18 @@ from scipy.optimize import linprog
 from ..mesh import GroupedBCs
 
 
+def _format_component_balance(connections, volumetric_flows, id_component: int) -> str:
+    """Build a compact per-component balance summary for debugging flow optimization failures."""
+    inlets, outlets = connections[id_component]
+    inlet_terms = [f"{id_connection}:{volumetric_flows[id_connection]:.6e}->{id_other}" for id_connection, id_other in inlets.items()]
+    outlet_terms = [f"{id_connection}:{volumetric_flows[id_connection]:.6e}->{id_other}" for id_connection, id_other in outlets.items()]
+    total_in = sum(volumetric_flows[id_connection] for id_connection in inlets)
+    total_out = sum(volumetric_flows[id_connection] for id_connection in outlets)
+    return (f"component {id_component}: total_in={total_in:.6e}, total_out={total_out:.6e}, "
+            f"net={total_in - total_out:.6e}, inlets=[{', '.join(inlet_terms)}], "
+            f"outlets=[{', '.join(outlet_terms)}]")
+
+
 def check_network_for_disconnected_subgraphs(connection_pairings: Dict[int, Dict[int, int]]) -> None:
     """
     Check if the resulting compartment network contains disconnected subgraphs.
@@ -323,7 +335,18 @@ def tweak_final_flows(
         # Summing to zero means that each time it was marked an inlet it is also marked as an outlet.
         # Domain inlets/outlet will not match up.
         if id_connection not in indices_of_domain_inlet_outlet:
-            assert np.sum(a[:, id_connection]) == 0
+            column_sum = np.sum(a[:, id_connection])
+            if column_sum != 0:
+                endpoints = []
+                for id_model, (inlets, outlets) in connections.items():
+                    if id_connection in inlets:
+                        endpoints.append(f"component {id_model} inlet from {inlets[id_connection]}")
+                    if id_connection in outlets:
+                        endpoints.append(f"component {id_model} outlet to {outlets[id_connection]}")
+                raise ValueError(
+                    f"Connection {id_connection} is not balanced in the assembled network: "
+                    f"column_sum={column_sum}, endpoints={endpoints}"
+                )
 
         # Each column must have at least one non-zero entry to indicate that it's been connected to something
         assert np.any(a[:, id_connection] != 0)
@@ -349,11 +372,24 @@ def tweak_final_flows(
         for id_connection in outlets.keys():
             b[i] += volumetric_flows[id_connection]
 
+    print(f"Flow optimization problem size: {a.shape[0]} components, {a.shape[1]} connections")
     print("BEFORE: MAX abs error: {:.4e}".format(np.max(abs(b)) * v_min))
     print("BEFORE: AVG abs error: {:.4e}".format(np.mean(abs(b)) * v_min))
+    unbalanced_components = np.flatnonzero(np.abs(b) * v_min > atol_opt)
+    if unbalanced_components.size:
+        print(f"Components exceeding atol_opt before optimization: {unbalanced_components.tolist()}")
+        for row_index in unbalanced_components[:10]:
+            print(_format_component_balance(connections, volumetric_flows * v_min, id_models[row_index]))
+
     # Solve the equation
     results = linprog(c, A_eq=a, b_eq=b, bounds=(0, None), integrality=2)
     if not results["success"]:
+        print("Flow optimization failed with diagnostics:")
+        print(f"status={results.get('status')}, message={results.get('message')}")
+        rank = int(np.linalg.matrix_rank(a.astype(float)))
+        print(f"constraint_matrix_rank={rank}, rows={a.shape[0]}, cols={a.shape[1]}")
+        for row_index, id_model in enumerate(id_models[:10]):
+            print(_format_component_balance(connections, volumetric_flows * v_min, id_model))
         raise Exception("Flow optimization did not converge. \n" +
                         "Message:" + results["message"])
 

--- a/openccm/compartmentalize/unidirectional.py
+++ b/openccm/compartmentalize/unidirectional.py
@@ -799,25 +799,41 @@ def _remove_unwanted_elements(mesh: CMesh, dir_vec: np.ndarray) -> Tuple[Set[int
     * valid_elements:     A set containing the IDs of the elements that are still valid for compartmentalization.
     """
     no_slip_facets = np.where(mesh.facet_to_bc_map == mesh.grouped_bcs.no_flux)[0]
+    # 1 for sharing a vertex in 2D, 2 for sharing an edge in 3D.
+    min_shared_vertices = 1 if mesh.vertices.shape[1] == 2 else 2
 
     # Remove the elements which have a magnitude of 0
     magnitude = np.linalg.norm(dir_vec, axis=1)
     removed_elements = set(np.where(magnitude == 0)[0])
 
-    # Remove elements which are on a no-slip boundary condition
+    # Remove elements which are on a no-slip boundary condition.
+    # Also remove neighbouring elements in the immediate wall layer, but preserve any element that is attached to a
+    # different named boundary such as an inlet or outlet.
+    # This is in particular important for triangular 2D and tetrahedra 3D meshes where a mesh element may have a single
+    # vertex on the no-slip boundary and itself would be impact in the same way as other triangles/tets with 2+ vertices
+    # on the no-slip.
     for facet in no_slip_facets:
         # A facet on a mesh boundary should only have one element
         elements = mesh.facet_elements[facet]
         assert len(elements) == 1
 
-        # 1. Add the element which has this facet
+        # 1. Remove the element which has this facet
         removed_elements.add(elements[0])
 
-        # 2. Add all elements that has any of the vertices from that facet
+        # 2. Remove neighbouring elements that lie in the same wall-adjacent layer.
+        #    In 2D this means sharing a vertex with the no-flux facet; in 3D it means sharing an edge.
+        #    Do not remove a candidate if it is attached to any other (non-no-flux) named boundary.
         bc_vertices = set(mesh.facet_vertices[facet])
         for element_neighbour in mesh.element_connectivity[elements[0]]:
-            if len(bc_vertices.intersection(mesh.element_vertices[element_neighbour])) > 0:
-                removed_elements.add(element_neighbour)
+            if len(bc_vertices.intersection(mesh.element_vertices[element_neighbour])) < min_shared_vertices:
+                continue
+
+            neighbour_bcs = {mesh.facet_to_bc_map[id_facet] for id_facet in mesh.element_facets[element_neighbour]
+                             if mesh.facet_to_bc_map[id_facet] < 0}
+            if any(id_bc != mesh.grouped_bcs.no_flux for id_bc in neighbour_bcs):
+                continue
+
+            removed_elements.add(element_neighbour)
 
     # A set to hold all elements which have had at least one element removed as a neighbour
     # Entries are added when one of their neighbours has been removed from the mesh

--- a/openccm/mesh/__init__.py
+++ b/openccm/mesh/__init__.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License along with OpenCCM. If not, see             #
 # <https://www.gnu.org/licenses/>.                                                                                     #
 ########################################################################################################################
-from typing import List, Tuple, Optional
+from typing import Dict, List, Tuple, Optional
 
 r"""
 The mesh module contains the intermediate mesh representation, CMesh, and the functions required to convert OpenFOAM
@@ -73,11 +73,16 @@ def convert_velocities_to_flows(cmesh: CMesh, vel_vec: np.ndarray) -> np.ndarray
     """
     flow = cmesh.facet_size.copy()
     upwind_element = np.zeros(len(flow), dtype=int)
+    boundary_fluxes: Dict[int, List[Tuple[int, float]]] = {}
     for facet, facet_elements in enumerate(cmesh.facet_elements):
         if len(facet_elements) == 1:
             flux = cmesh.facet_normals[facet].dot(vel_vec[facet_elements[0]])
             flow[facet] = abs(flux) * cmesh.facet_size[facet]
             upwind_element[facet] = 0 if flux >= 0 else -1
+
+            bc_id = cmesh.facet_to_bc_map[facet]
+            if bc_id < 0:
+                boundary_fluxes.setdefault(int(bc_id), []).append((facet, float(flux)))
         elif len(facet_elements) == 2:
             flux_0 = cmesh.get_outward_facing_normal(facet, facet_elements[0]).dot(vel_vec[facet_elements[0]])
             flux_1 = cmesh.get_outward_facing_normal(facet, facet_elements[1]).dot(vel_vec[facet_elements[1]])
@@ -94,7 +99,44 @@ def convert_velocities_to_flows(cmesh: CMesh, vel_vec: np.ndarray) -> np.ndarray
         else:
             raise ValueError(f'Facet {facet} has {len(facet_elements)} elements, but should only have 1 or 2.')
 
+    _validate_boundary_facet_directions(cmesh, boundary_fluxes)
+
     return np.array([flow, upwind_element], dtype=object).transpose()
+
+
+def _validate_boundary_facet_directions(cmesh: CMesh, boundary_fluxes: Dict[int, List[Tuple[int, float]]]) -> None:
+    bc_id_to_name = {
+        cmesh.grouped_bcs.id(name): name
+        for name in (cmesh.grouped_bcs.domain_inlet_names + cmesh.grouped_bcs.domain_outlet_names)
+    }
+
+    violations = []
+    for bc_id in cmesh.grouped_bcs.domain_inlets:
+        reversed_facets = [(facet, flux) for facet, flux in boundary_fluxes.get(bc_id, []) if flux > 0.0]
+        if reversed_facets:
+            sample_facets = [facet for facet, _ in reversed_facets[:10]]
+            fluxes = [flux for _, flux in reversed_facets]
+            violations.append(
+                f"Inlet BC '{bc_id_to_name.get(bc_id, str(bc_id))}' ({bc_id}) has {len(reversed_facets)} facets with outflow; "
+                f"sample facets {sample_facets}; signed flux range [{min(fluxes):.6e}, {max(fluxes):.6e}]"
+            )
+
+    for bc_id in cmesh.grouped_bcs.domain_outlets:
+        reversed_facets = [(facet, flux) for facet, flux in boundary_fluxes.get(bc_id, []) if flux < 0.0]
+        if reversed_facets:
+            sample_facets = [facet for facet, _ in reversed_facets[:10]]
+            fluxes = [flux for _, flux in reversed_facets]
+            violations.append(
+                f"Outlet BC '{bc_id_to_name.get(bc_id, str(bc_id))}' ({bc_id}) has {len(reversed_facets)} facets with inflow; "
+                f"sample facets {sample_facets}; signed flux range [{min(fluxes):.6e}, {max(fluxes):.6e}]"
+            )
+
+    if violations:
+        raise ValueError(
+            "Detected reversed flow on configured domain boundaries. "
+            "Each inlet facet must have inflow or zero, and each outlet facet must have outflow or zero.\n"
+            + "\n".join(violations)
+        )
 
 
 def create_dof_to_element_map(model_to_element_map: List[List[Tuple[float, int]]], points_per_model: int) -> List[List[Tuple[int, int, float]]]:


### PR DESCRIPTION
1. Add check for flow inversion in inlet BCs and error out.
2. Fix bug in how no-flux BCs propagated removal of elements. Elements that have a vertex on a no-flux BC should only be removed if they are **not** part of another BC.
3. Add better logging for optimization failures due to infeasible solutions to simplify debugging.